### PR TITLE
Adiciona model de tipo de unidade e faz associacoes

### DIFF
--- a/app/models/condo.rb
+++ b/app/models/condo.rb
@@ -1,2 +1,4 @@
 class Condo < ApplicationRecord
+  has_many :unit_types
+  has_many :units, through: :unit_types
 end

--- a/app/models/unit_type.rb
+++ b/app/models/unit_type.rb
@@ -1,0 +1,4 @@
+class UnitType < ApplicationRecord
+  belongs_to :condo
+  has_many :units
+end

--- a/db/migrate/20240625175041_create_unit_types.rb
+++ b/db/migrate/20240625175041_create_unit_types.rb
@@ -1,0 +1,12 @@
+class CreateUnitTypes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :unit_types do |t|
+      t.string :description
+      t.integer :area
+      t.float :ideal_fraction
+      t.references :condo, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240625175210_add_unit_type_to_unit.rb
+++ b/db/migrate/20240625175210_add_unit_type_to_unit.rb
@@ -1,0 +1,5 @@
+class AddUnitTypeToUnit < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :units, :unit_type, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_24_193010) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_175210) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -56,12 +56,26 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_24_193010) do
     t.index ["reset_password_token"], name: "index_property_owners_on_reset_password_token", unique: true
   end
 
+  create_table "unit_types", force: :cascade do |t|
+    t.string "description"
+    t.integer "area"
+    t.float "ideal_fraction"
+    t.integer "condo_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["condo_id"], name: "index_unit_types_on_condo_id"
+  end
+
   create_table "units", force: :cascade do |t|
     t.integer "area"
     t.integer "floor"
     t.integer "number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "unit_type_id", null: false
+    t.index ["unit_type_id"], name: "index_units_on_unit_type_id"
   end
 
+  add_foreign_key "unit_types", "condos"
+  add_foreign_key "units", "unit_types"
 end

--- a/spec/factories/unit_types.rb
+++ b/spec/factories/unit_types.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :unit_type do
+    description { "MyString" }
+    area { 1 }
+    ideal_fraction { 1.5 }
+    condo { nil }
+  end
+end

--- a/spec/models/unit_type_spec.rb
+++ b/spec/models/unit_type_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UnitType, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Nesse PR nós criamos um model pra tipos de unidades (unit_types) e criamos associações entre os models já existentes. Essa ação foi necessária pra desenvolver as primeiras funcionalidades do projeto.