### PR TITLE
Campo de Busca na Listagem de Condomínios

### DIFF
--- a/app/controllers/condos_controller.rb
+++ b/app/controllers/condos_controller.rb
@@ -8,4 +8,10 @@ class CondosController < ApplicationController
   def show
     @condo = Condo.find(params[:id])
   end
+
+  def search
+    @query = params[:query].downcase
+    @condos = Condo.all.select { |condo| condo.name.downcase.include?(@query) }
+    render 'index'
+  end
 end

--- a/app/controllers/shared_fees_controller.rb
+++ b/app/controllers/shared_fees_controller.rb
@@ -8,7 +8,7 @@ class SharedFeesController < ApplicationController
 
   def show
     @shared_fee = SharedFee.find(params[:id])
-    @condo = Condo.find(params[:condo_id])
+    @condo = Condo.find(@shared_fee.condo_id)
   end
 
   def new

--- a/app/views/base_fees/new.html.erb
+++ b/app/views/base_fees/new.html.erb
@@ -15,7 +15,7 @@
   <div class="row">
     <div class="col-md-6 form-base-fees">
       <%= form_with model: [@base_fee], url: condo_base_fees_path(@condo.id), local: true do |f| %>
-        <%= hidden_field_tag :condo_id, @condo.id %>
+        <%= f.hidden_field :condo_id, value: @condo.id %>
 
       <div class="form-group">
         <%= f.label :name %>

--- a/app/views/condos/index.html.erb
+++ b/app/views/condos/index.html.erb
@@ -1,5 +1,15 @@
 <h1><strong>Listagem de Condomínios</strong></h1>
- 
+<%= form_with url: search_condos_path, method: :get do |f| %>
+  <div class="d-flex">
+    <%= f.text_field :query, class: 'form-control', placeholder: 'Busque um condomínio' %>
+    <%= f.submit 'Buscar' %>
+  </div>
+<% end %>
+<% if @query  %>
+  <div>
+    <%= @query == "" ? "Você precisa buscar por um nome de condomínio" : "Resultados para: '#{@query}'" %>
+  </div>
+<% end %>
 <% if @condos.any? %>
   <table class="table">
     <thead>
@@ -18,5 +28,9 @@
     </tbody>
   </table>
 <% else %>
-  <strong>Não existem condomínios registrados.</strong>
+  <% if @query %>
+    <strong>Não foram encontrados condomínios para essa busca.</strong>
+  <% else %>
+    <strong>Não existem condomínios registrados.</strong>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :condos, only: [:index, :show] do
     resources :common_areas, only: [:index, :show, :edit, :update]
     resources :base_fees, only: [:new, :create, :show, :index]
+    get 'search', on: :collection
   end
 
   resources :shared_fees, only: [:index, :show, :new, :create]

--- a/spec/models/condo_spec.rb
+++ b/spec/models/condo_spec.rb
@@ -17,5 +17,16 @@ describe Condo do
       expect(result[2].name).to eq 'Sai do Meio'
       expect(result[2].city).to eq 'Minas Gerais'
     end
+
+    it '.find' do
+      data = Rails.root.join('spec/support/json/condo.json').read
+      response = double('response', success?: true, body: data)
+      allow(Faraday).to receive(:get).with('http://127.0.0.1:3000/api/v1/condos/1').and_return(response)
+
+      result = Condo.find(1)
+
+      expect(result.name).to eq 'Sai de Baixo'
+      expect(result.city).to eq 'Rio de Janeiro'
+    end
   end
 end

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -1,5 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe Unit, type: :model do
-  # Empty test
+describe Unit do
+  context '.all' do
+    it 'retorna todos as unidades' do
+      data = Rails.root.join('spec/support/json/units.json').read
+      response = double('response', success?: true, body: data)
+      allow(Faraday).to receive(:get).with('http://127.0.0.1:3000/api/v1/units').and_return(response)
+
+      result = Unit.all
+
+      expect(result.length).to eq 3
+      expect(result[0].area).to eq 100
+      expect(result[0].floor).to eq 1
+      expect(result[0].number).to eq 1
+      expect(result[1].area).to eq 200
+      expect(result[1].floor).to eq 2
+      expect(result[1].number).to eq 2
+      expect(result[2].area).to eq 300
+      expect(result[2].floor).to eq 3
+      expect(result[2].number).to eq 3
+    end
+  end
 end

--- a/spec/models/unit_type_spec.rb
+++ b/spec/models/unit_type_spec.rb
@@ -15,4 +15,19 @@ describe UnitType do
       expect(result[2].description).to eq 'yet another thing'
     end
   end
+
+  context '.find' do
+    it 'retorna um tipo de unidade especifico' do
+      data = Rails.root.join('spec/support/json/unit_type.json').read
+      response = double('response', success?: true, body: data)
+      allow(Faraday).to receive(:get).with('http://127.0.0.1:3000/api/v1/unit_types/1').and_return(response)
+
+      result = UnitType.find(1)
+
+      expect(result.area).to eq 1000
+      expect(result.description).to eq 'something'
+      expect(result.ideal_fraction).to eq 200.2
+      expect(result.condo_id).to eq 1
+    end
+  end
 end

--- a/spec/support/json/condo.json
+++ b/spec/support/json/condo.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sai de Baixo",
+  "city": "Rio de Janeiro",
+  "id": "1"
+}

--- a/spec/support/json/unit_type.json
+++ b/spec/support/json/unit_type.json
@@ -1,0 +1,7 @@
+{
+  "area": 1000,
+  "description": "something",
+  "ideal_fraction": 200.2,
+  "id": 1,
+  "condo_id": 1
+}

--- a/spec/system/condos/admin_search_condos_by_name_spec.rb
+++ b/spec/system/condos/admin_search_condos_by_name_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe 'Admin busca condomínio pelo nome' do
+  it 'com sucesso' do
+    admin = create(:admin)
+    condos = []
+    condos << Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    condos << Condo.new(id: 2, name: 'Residencial Jardim Europa', city: 'Maceió')
+    condos << Condo.new(id: 3, name: 'Edifício Monte Verde', city: 'Recife')
+    condos << Condo.new(id: 4, name: 'Condomínio Lagoa Verde', city: 'Caxias do Sul')
+    allow(Condo).to receive(:all).and_return(condos)
+
+    login_as admin, scope: :admin
+    visit root_path
+    click_on 'Lista de Condomínios'
+    fill_in 'Busque um condomínio',	with: 'verde'
+    click_on 'Buscar'
+
+    expect(page).to have_content "Resultados para: 'verde'"
+    expect(page).to have_content 'Edifício Monte Verde'
+    expect(page).to have_content 'Condomínio Lagoa Verde'
+    expect(page).not_to have_content 'Condomínio Vila das Flores'
+    expect(page).not_to have_content 'Residencial Jardim Europa'
+  end
+
+  it 'e retorna alerta se nao encontrar condominios' do
+    admin = create(:admin)
+    condos = []
+    condos << Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    allow(Condo).to receive(:all).and_return(condos)
+
+    login_as admin, scope: :admin
+    visit root_path
+    click_on 'Lista de Condomínios'
+    fill_in 'Busque um condomínio',	with: 'Teste'
+    click_on 'Buscar'
+
+    expect(page).to have_content 'Não foram encontrados condomínios para essa busca.'
+    expect(page).not_to have_content 'Não existem condomínios registrados.'
+    expect(page).not_to have_content 'Condomínio Vila das Flores'
+  end
+
+  it 'e retorna alerta caso o termo da busca seja vazio' do
+    admin = create(:admin)
+    condos = []
+    condos << Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    allow(Condo).to receive(:all).and_return(condos)
+
+    login_as admin, scope: :admin
+    visit root_path
+    click_on 'Lista de Condomínios'
+    fill_in 'Busque um condomínio',	with: ''
+    click_on 'Buscar'
+
+    expect(page).to have_content 'Você precisa buscar por um nome de condomínio'
+  end
+end


### PR DESCRIPTION
O que está feito: Campo de Busca na listagem de condomínios que busca pelo nome do condomínio.

Alterações adicionais: Correções nos Base_Fee e Shared_Fee que não estavam recebendo o ID de condominio corretamente

![image](https://github.com/TreinaDev/pague-aluguel/assets/119768060/6a2ed06c-8ef0-4d58-8506-898660fdedb2)
