### PR TITLE
 Navegação para Conta Compartilhada

### DIFF
--- a/app/views/condos/show.html.erb
+++ b/app/views/condos/show.html.erb
@@ -7,7 +7,7 @@
         Gerenciar Condomínio
       </a>
       <ul class="dropdown-menu">
-        <%= link_to 'Contas Compartilhadas', shared_fees_path(condo_id: @condo.id), class: 'dropdown-item' %>
+        <%= link_to 'Contas Compartilhadas', condo_shared_fees_path(condo_id: @condo.id), class: 'dropdown-item' %>
         <%= link_to 'Exibir Áreas Comuns', condo_common_areas_path(condo_id: @condo.id), class: 'dropdown-item' %>
         <%= link_to 'Cadastrar Nova Taxa', new_condo_base_fee_path(condo_id: @condo.id), class: 'dropdown-item' %>
         <%= link_to 'Exibir Taxas Cadastradas', condo_base_fees_path(condo_id: @condo.id), class: 'dropdown-item' %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,6 @@
 <h1>Cola?Bora!</h1>
 
 <div>
-  <%= link_to 'Lançar Conta Compartilhada', new_shared_fee_path %>
-</div>
-<div>
   <%= link_to 'Lista de Condomínios', condos_path %>
 </div>
 

--- a/app/views/shared_fees/index.html.erb
+++ b/app/views/shared_fees/index.html.erb
@@ -13,7 +13,7 @@
       <tbody>
         <% @shared_fees.each do |shared_fee| %>
           <tr>
-            <td><%= link_to "#{shared_fee.description}", shared_fee_path(shared_fee) %></td>
+            <td><%= link_to "#{shared_fee.description}", condo_shared_fee_path(shared_fee.condo_id, shared_fee) %></td>
             <td><%= I18n.l(shared_fee.issue_date) %></td>
             <td><%= shared_fee.total_value.format %></td>
             <% if shared_fee.active? %>
@@ -31,7 +31,7 @@
 
   <div class="row">
     <div class="col-md-6">
-      <%= link_to 'Lançar Conta Compartilhada', new_shared_fee_path(condo_id: @condo.id), class: 'btn btn-primary' %>
+      <%= link_to 'Lançar Conta Compartilhada', new_condo_shared_fee_path(condo_id: @condo.id), class: 'btn btn-primary' %>
     </div>
     <div class="col-md-6">
       <%= link_to I18n.t('helpers.buttons.back'), condo_path(@condo.id), class: "btn btn-secondary" %>

--- a/app/views/shared_fees/new.html.erb
+++ b/app/views/shared_fees/new.html.erb
@@ -14,12 +14,7 @@
 
   <div class="row">
     <div class="col-md-6">
-      <%= form_with model: @shared_fee, local: true do |f| %> 
-        <div class="form-group">
-          <%= f.label :condo_id %>
-          <%= f.collection_select :condo_id, @condos, :id, :name, selected: @selected_condo_id, class: "form-control" %>
-        </div>
-
+      <%= form_with model: @shared_fee, url: condo_shared_fees_path, local: true do |f| %> 
         <div class="form-group">
           <%= f.label :description %>
           <%= f.text_field :description, class: "form-control" %>

--- a/app/views/shared_fees/show.html.erb
+++ b/app/views/shared_fees/show.html.erb
@@ -39,11 +39,11 @@
   <div class="row">
     <% if @shared_fee.active? %>
       <div class="col-md-6">
-        <%= button_to I18n.t('cancel-button'), cancel_shared_fee_path(@shared_fee), class: 'btn btn-danger' %>
+        <%= button_to I18n.t('cancel-button'), cancel_condo_shared_fee_path(@condo.id, @shared_fee), class: 'btn btn-danger' %>
       </div>
     <% end %>
     <div class="col-md-6">
-      <%= link_to I18n.t('helpers.buttons.back'), shared_fees_path(condo_id: @condo.id), class: "btn btn-secondary" %>
+      <%= link_to I18n.t('helpers.buttons.back'), condo_shared_fees_path(@condo.id), class: "btn btn-secondary" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,13 @@ Rails.application.routes.draw do
     resources :common_areas, only: [:index, :show, :edit, :update]
     resources :base_fees, only: [:new, :create, :show, :index]
     get 'search', on: :collection
+
+    resources :shared_fees, only: [:index, :show, :new, :create] do
+      post 'cancel', on: :member
+    end
   end
 
-  resources :shared_fees, only: [:index, :show, :new, :create] do 
-    post 'cancel', on: :member
-  end
+
 
   authenticate :admin do
     resources :admins, only: [:index, :show]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,8 +133,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_185220) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "price_currency", default: "USD", null: false
-    t.integer "price_cents"
     t.integer "unit_type_id"
+    t.integer "price_cents"
     t.index ["base_fee_id"], name: "index_values_on_base_fee_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,8 +133,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_185220) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "price_currency", default: "USD", null: false
-    t.integer "unit_type_id"
     t.integer "price_cents"
+    t.integer "unit_type_id"
     t.index ["base_fee_id"], name: "index_values_on_base_fee_id"
   end
 

--- a/spec/requests/shared_fees/shared_fees_spec.rb
+++ b/spec/requests/shared_fees/shared_fees_spec.rb
@@ -23,14 +23,14 @@ describe 'Admin gerencia contas compartilhadas' do
       allow(UnitType).to receive(:all).and_return(unit_types)
 
       login_as admin, scope: :admin
-      post(shared_fees_path, params: { shared_fee: { description: 'Descrição',
-                                                     issue_date: 10.days.from_now.to_date,
-                                                     total_value: 1000,
-                                                     condo_id: condos.first.id } })
+      post(condo_shared_fees_path(condos.first.id), params: { shared_fee: { description: 'Descrição',
+                                                                            issue_date: 10.days.from_now.to_date,
+                                                                            total_value: 1000 } })
 
       expect(SharedFee.count).to eq 1
+      expect(SharedFee.last.shared_fee_fractions.length).to eq 2
       expect(response).to have_http_status(302)
-      expect(response).to redirect_to(shared_fee_path(SharedFee.last.id.to_s))
+      expect(response).to redirect_to(condo_shared_fee_path(condos.first.id, SharedFee.last.id))
       expect(SharedFee.last.description).to eq 'Descrição'
       expect(SharedFee.last.issue_date).to eq 10.days.from_now.to_date
       expect(SharedFee.last.total_value_cents).to eq 100_000
@@ -56,10 +56,13 @@ describe 'Admin gerencia contas compartilhadas' do
       allow(Condo).to receive(:all).and_return(condos)
       allow(UnitType).to receive(:all).and_return(unit_types)
 
-      post(shared_fees_path, params: { shared_fee: { description: 'Descrição',
-                                                     issue_date: 10.days.from_now.to_date,
-                                                     total_value_cents: 1000,
-                                                     condo_id: condos.first.id } })
+      post(condo_shared_fees_path(condos.first.id), params: {
+             shared_fee: {
+               description: 'Descrição',
+               issue_date: 10.days.from_now.to_date,
+               total_value_cents: 1000
+             }
+           })
 
       expect(SharedFee.count).to eq 0
       expect(response).to have_http_status(302)
@@ -93,22 +96,19 @@ describe 'Admin gerencia contas compartilhadas' do
       sf = SharedFee.create!(description: 'Conta de Luz', issue_date: 10.days.from_now.to_date,
                              total_value: 10_000, condo_id: condos.first.id)
 
+      shared_fee_fractions = SharedFee.last.shared_fee_fractions
+      shared_fee_fractions_are_canceled = shared_fee_fractions.all?(&:canceled?)
+
       login_as admin, scope: :admin
-      post(cancel_shared_fee_path(sf.id))
+      post(cancel_condo_shared_fee_path(condos.first.id, sf.id))
 
       expect(SharedFee.last.canceled?).to eq true
+      expect(shared_fee_fractions_are_canceled).to eq true
       expect(response).to have_http_status(302)
-      expect(response).to redirect_to(shared_fees_path(condo_id: condos.first.id))
+      expect(response).to redirect_to(condo_shared_fees_path(condos.first.id))
     end
 
     it 'e não está autenticado' do
-      Admin.create!(
-        email: 'admin@mail.com',
-        password: '123456',
-        first_name: 'Fulano',
-        last_name: 'Da Costa',
-        document_number: CPF.generate
-      )
       condos = []
       condos << Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
       unit_types = []
@@ -124,7 +124,7 @@ describe 'Admin gerencia contas compartilhadas' do
       sf = SharedFee.create!(description: 'Conta de Luz', issue_date: 10.days.from_now.to_date,
                              total_value: 10_000, condo_id: condos.first.id)
 
-      post(cancel_shared_fee_path(sf.id))
+      post(cancel_condo_shared_fee_path(condos.first.id, sf.id))
 
       expect(SharedFee.last.canceled?).to eq false
       expect(response).to have_http_status(302)

--- a/spec/requests/shared_fees/shared_fees_spec.rb
+++ b/spec/requests/shared_fees/shared_fees_spec.rb
@@ -20,6 +20,7 @@ describe 'Admin gerencia contas compartilhadas' do
       units << Unit.new(id: 2, area: 100, floor: 1, number: 1, unit_type_id: 2)
       allow(Unit).to receive(:all).and_return(units)
       allow(Condo).to receive(:all).and_return(condos)
+      allow(Condo).to receive(:find).and_return(condos.first)
       allow(UnitType).to receive(:all).and_return(unit_types)
 
       login_as admin, scope: :admin

--- a/spec/system/shared_fees/admin_access_shared_fee_list_spec.rb
+++ b/spec/system/shared_fees/admin_access_shared_fee_list_spec.rb
@@ -58,7 +58,7 @@ describe 'Admin tenta acessar lista de contas compartilhadas' do
                       total_value: 25_000, condo_id: condos.first.id)
 
     login_as admin, scope: :admin
-    visit shared_fees_path(condo_id: condos.first.id)
+    visit condo_shared_fees_path(condo_id: condos.first.id)
     click_on 'Voltar'
 
     expect(current_path).to eq condo_path(condos.first.id)
@@ -92,7 +92,7 @@ describe 'Admin tenta acessar lista de contas compartilhadas' do
     click_on 'Contas Compartilhadas'
     click_on 'Conta de Água'
 
-    expect(current_path).to eq shared_fee_path(conta_de_agua.id)
+    expect(current_path).to eq condo_shared_fee_path(condos.first.id, conta_de_agua.id)
     expect(page).to have_content 'Conta de Água'
     expect(page).to have_content 'R$5.000,00'
   end
@@ -113,17 +113,20 @@ describe 'Admin tenta acessar lista de contas compartilhadas' do
                       total_value: 10_000, condo_id: condos.first.id)
 
     login_as admin, scope: :admin
-    visit shared_fees_path(condo_id: condos.first.id)
+    visit condo_shared_fees_path(condos.first.id)
     click_on 'Conta de Luz'
     click_on 'Voltar'
 
-    expect(current_path).to eq shared_fees_path
+    expect(current_path).to eq condo_shared_fees_path(condos.first.id)
   end
 
   it 'e não está autenticado' do
     FactoryBot.create(:admin, first_name: 'Fulano', last_name: 'Da Costa')
 
-    visit shared_fees_path
+    condo = Condo.new(id: 1, name: 'Edifício Monte Verde', city: 'Recife')
+    allow(Condo).to receive(:find).and_return(condo)
+
+    visit condo_shared_fees_path(condo.id)
 
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
     expect(current_path).to eq new_admin_session_path
@@ -148,6 +151,6 @@ describe 'Admin tenta acessar lista de contas compartilhadas' do
 
     expect(page).to have_content('Não foram encontradas contas compartilhadas.')
     expect(page).to have_link('Lançar Conta Compartilhada')
-    expect(current_path).to eq shared_fees_path
+    expect(current_path).to eq condo_shared_fees_path(condos.first.id)
   end
 end

--- a/spec/system/shared_fees/admin_cancels_shared_fee_spec.rb
+++ b/spec/system/shared_fees/admin_cancels_shared_fee_spec.rb
@@ -29,7 +29,7 @@ describe 'Admin cancela uma conta compartilhada' do
     expect(page).to have_content "#{bill.description} cancelada com sucesso"
     expect(bill.active?).to eq false
     expect(bill.canceled?).to eq true
-    expect(current_path).to eq shared_fees_path
+    expect(current_path).to eq condo_shared_fees_path(condos.first.id)
     expect(page).to have_content 'Cancelada'
   end
 

--- a/spec/system/shared_fees/admin_creates_shared_fee_spec.rb
+++ b/spec/system/shared_fees/admin_creates_shared_fee_spec.rb
@@ -20,15 +20,19 @@ describe 'Admin lança uma conta compartilhada' do
 
     login_as admin, scope: :admin
     visit root_path
+    click_on 'Lista de Condomínios'
+    click_on 'Condo Test'
+    click_on 'Gerenciar Condomínio'
+    click_on 'Contas Compartilhadas'
     click_on 'Lançar Conta Compartilhada'
-    select 'Condo Test', from: 'Condomínio'
     fill_in 'Descrição', with: 'Conta de Luz'
     fill_in 'Data de Emissão', with: 10.days.from_now.to_date
     fill_in 'Valor Total', with: 10_000
     click_on 'Registrar'
 
     expect(page).to have_content('Conta Compartilhada lançada com sucesso!')
-    expect(current_path).to eq(shared_fee_path(SharedFee.last))
+    expect(current_path).to eq(condo_shared_fee_path(condos.first.id, SharedFee.last))
+    expect(SharedFee.last.condo_id).to eq 1
     expect(page).to have_content('Condomínio: Condo Test')
     expect(page).to have_content('Descrição: Conta de Luz')
     expect(page).to have_content("Data de Emissão: #{I18n.l(10.days.from_now.to_date)}")
@@ -39,7 +43,10 @@ describe 'Admin lança uma conta compartilhada' do
   it 'e não está autenticado' do
     FactoryBot.create(:admin, first_name: 'Fulano', last_name: 'Da Costa')
 
-    visit new_shared_fee_path
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    allow(Condo).to receive(:find).and_return(condo)
+
+    visit new_condo_shared_fee_path(condo.id)
 
     expect(page).to have_content('Para continuar, faça login ou registre-se.')
     expect(current_path).to eq new_admin_session_path
@@ -64,10 +71,14 @@ describe 'Admin lança uma conta compartilhada' do
 
     login_as admin, scope: :admin
     visit root_path
+    click_on 'Lista de Condomínios'
+    click_on 'Condo Test'
+    click_on 'Gerenciar Condomínio'
+    click_on 'Contas Compartilhadas'
     click_on 'Lançar Conta Compartilhada'
     click_on 'Registrar'
 
-    expect(current_path).to eq(new_shared_fee_path)
+    expect(current_path).to eq(new_condo_shared_fee_path(condos.first.id))
     expect(page).to have_content('Não foi possível lançar a conta compartilhada.')
     expect(page).to have_content('Descrição não pode ficar em branco')
     expect(page).to have_content('Data de Emissão não pode ficar em branco')
@@ -82,11 +93,11 @@ describe 'Admin lança uma conta compartilhada' do
     allow(Condo).to receive(:find).and_return(condos.first)
 
     login_as admin, scope: :admin
-    visit shared_fees_path(condo_id: condos.first.id)
+    visit condo_shared_fees_path(condos.first.id)
     click_on 'Lançar Conta Compartilhada'
     click_on 'Voltar'
 
-    expect(current_path).to eq shared_fees_path
+    expect(current_path).to eq condo_shared_fees_path(condos.first.id)
   end
 
   it 'e lança mais de uma conta' do
@@ -114,8 +125,11 @@ describe 'Admin lança uma conta compartilhada' do
 
     login_as admin, scope: :admin
     visit root_path
+    click_on 'Lista de Condomínios'
+    click_on 'Condo Test'
+    click_on 'Gerenciar Condomínio'
+    click_on 'Contas Compartilhadas'
     click_on 'Lançar Conta Compartilhada'
-    select 'Condo Test', from: 'Condomínio'
     fill_in 'Descrição', with: 'Conta de Água'
     fill_in 'Data de Emissão', with: 10.days.from_now.to_date
     fill_in 'Valor Total', with: 5_000


### PR DESCRIPTION
O que foi feito: SharedFee foi movido para uma rota aninhada de Condo. Testes refatorados e links nas views relacionadas alterados. Retiramos também o link de "Lançar conta compartilhada" da homepage. O selection box do form de SharedFee foi removido, pois com as rotas aninhadas perde-se esta necessidade. 

Testes de request de SharedFee foram incrementados para garantir que o model SharedFeeFractions se comporta de forma esperada.

![image](https://github.com/TreinaDev/pague-aluguel/assets/106618686/ceb5b023-3d02-4192-a7a8-ad9b9b64aa7f)

![image](https://github.com/TreinaDev/pague-aluguel/assets/106618686/80ba62de-5e4f-462d-a625-3ea7f1c3fa18)

![image](https://github.com/TreinaDev/pague-aluguel/assets/106618686/787a5bc1-88e6-4d77-bde6-c857d23b5e70)

