### PR TITLE
Fix do endpoint de taxas de áreas comuns

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,57 @@ Para testar a plataforma PagueAluguel como administrador ou proprietário de im�
 
 Você pode usar sites como [4Devs](https://www.4devs.com.br/) para gerar números válidos que podem ser usados para cadastro na plataforma.
 
+#Pague Aluguel API
+
+## Taxas de Áreas Comuns 
+
+`GET /api/v1/condos/:id/common_area_fees`
+
+Recebe como parâmetro `:id` de um condomínio, e retorna uma lista com **a última taxa cadastrada para cada área comum desse condomínio**
+Retorna:
+Caso o condomínio não possua nenhuma taxa cadastrada: `status: 200, json: []`
+Caso o condomínio possua alguma taxa cadastrada: `status: 200, json:`
+``` 
+[ 
+  {
+    "id":1,
+    "value_cents":20000,
+    "created_at":"2024-07-11T21:09:13.019Z",
+    "common_area_id":1,
+    "condo_id":1,
+  },
+  {
+    "id":2,
+    "value_cents":30000,
+    "created_at":"2024-07-11T21:09:13.024Z",
+    "common_area_id":2,
+    "condo_id":1
+  },
+  {
+    "id":3,
+    "value_cents":40000,
+    "created_at":"2024-07-11T21:09:13.027Z",
+    "common_area_id":3,
+    "condo_id":1
+  }
+] 
+```
+
+`GET /api/v1/common_area_fees/:id`
+
+Recebe como parâmetro o `:id` de uma taxa cadastrada e retorna **os detalhes da taxa de área comum** desejada
+Retorna:
+Caso não exista taxa com o id informado: `status: 404, json: { "errors":"Não encontrado" } `
+Caso o condomínio possua alguma taxa cadastrada: `status: 200, json:`
+``` 
+{
+  "value_cents":20000,
+  "created_at":"2024-07-11T21:09:13.019Z",
+  "common_area_id":1,
+  "condo_id":1
+} 
+```
+
 ## Desenvolvedores 🧑🏽‍💻🧑🏻‍💻🧑‍💻
 
 <div align="center">

--- a/app/controllers/api/v1/common_area_fees_controller.rb
+++ b/app/controllers/api/v1/common_area_fees_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::CommonAreaFeesController < Api::V1::ApiController
   def index
     condo_id = params[:condo_id]
-    common_area_fees = find_most_recent_fee(condo_id)
+    common_area_fees = find_most_recent_fees(condo_id)
 
-    render status: :ok, json: common_area_fees.as_json(except: [:updated_at, :admin_id, :id])
+    render status: :ok, json: common_area_fees.as_json(except: [:updated_at, :admin_id])
   end
 
   def show
@@ -15,7 +15,7 @@ class Api::V1::CommonAreaFeesController < Api::V1::ApiController
 
   private
 
-  def find_most_recent_fee(condo_id)
+  def find_most_recent_fees(condo_id)
     fees = CommonAreaFee.where(condo_id:)
     current_fees = []
     fees.each do |fee|

--- a/spec/requests/apis/common_area_fee_api_spec.rb
+++ b/spec/requests/apis/common_area_fee_api_spec.rb
@@ -77,8 +77,9 @@ describe 'API das Áreas Comuns' do
   context 'GET /api/v1/common_area_fees/:id' do
     it 'sucesso' do
       admin = create(:admin)
-      common_area_fee = create(:common_area_fee, value_cents: 200_00, admin:, common_area_id: 1, condo_id: 1)
+      create(:common_area_fee, value_cents: 200_00, admin:, common_area_id: 1, condo_id: 1)
       create(:common_area_fee, value_cents: 300_00, admin:, common_area_id: 2, condo_id: 1)
+      common_area_fee = create(:common_area_fee, value_cents: 400_00, admin:, common_area_id: 1, condo_id: 1)
 
       get api_v1_common_area_fee_path(common_area_fee)
 
@@ -86,7 +87,7 @@ describe 'API das Áreas Comuns' do
       expect(response.content_type).to include 'application/json'
       json_response = response.parsed_body
 
-      expect(json_response['value_cents']).to eq 200_00
+      expect(json_response['value_cents']).to eq 400_00
       expect(json_response['common_area_id']).to eq 1
       expect(json_response['condo_id']).to eq 1
       expect(json_response.keys).not_to include('updated_at')

--- a/spec/requests/apis/common_area_fee_api_spec.rb
+++ b/spec/requests/apis/common_area_fee_api_spec.rb
@@ -4,9 +4,9 @@ describe 'API das Áreas Comuns' do
   context 'GET /api/v1/condos/:id/common_area_fees' do
     it 'sucesso' do
       admin = create(:admin)
-      create(:common_area_fee, value_cents: 200_00, admin:, common_area_id: 1, condo_id: 1)
-      create(:common_area_fee, value_cents: 300_00, admin:, common_area_id: 2, condo_id: 1)
-      create(:common_area_fee, value_cents: 400_00, admin:, common_area_id: 3, condo_id: 1)
+      common_area_fee1 = create(:common_area_fee, value_cents: 200_00, admin:, common_area_id: 1, condo_id: 1)
+      common_area_fee2 = create(:common_area_fee, value_cents: 300_00, admin:, common_area_id: 2, condo_id: 1)
+      common_area_fee3 = create(:common_area_fee, value_cents: 400_00, admin:, common_area_id: 3, condo_id: 1)
       create(:common_area_fee, value_cents: 500_00, admin:, common_area_id: 4, condo_id: 2)
       create(:common_area_fee, value_cents: 600_00, admin:, common_area_id: 5, condo_id: 3)
 
@@ -19,15 +19,17 @@ describe 'API das Áreas Comuns' do
       expect(json_response[0]['value_cents']).to eq 200_00
       expect(json_response[0]['common_area_id']).to eq 1
       expect(json_response[0]['condo_id']).to eq 1
+      expect(json_response[0]['id']).to eq common_area_fee1.id
       expect(json_response[0].keys).not_to include('updated_at')
       expect(json_response[0].keys).not_to include('admin_id')
-      expect(json_response[0].keys).not_to include('id')
       expect(json_response[1]['value_cents']).to eq 300_00
       expect(json_response[1]['common_area_id']).to eq 2
       expect(json_response[1]['condo_id']).to eq 1
+      expect(json_response[1]['id']).to eq common_area_fee2.id
       expect(json_response[2]['value_cents']).to eq 400_00
       expect(json_response[2]['common_area_id']).to eq 3
       expect(json_response[2]['condo_id']).to eq 1
+      expect(json_response[2]['id']).to eq common_area_fee3.id
     end
 
     it 'e não há taxas cadastradas' do
@@ -44,10 +46,14 @@ describe 'API das Áreas Comuns' do
 
     it 'e retorna a última taxa cadastrada para cada área comum' do
       admin = create(:admin)
-      create(:common_area_fee, value_cents: 200_00, admin:, common_area_id: 1, condo_id: 1, created_at: 2.days)
-      create(:common_area_fee, value_cents: 300_00, admin:, common_area_id: 1, condo_id: 1, created_at: 1.day)
-      create(:common_area_fee, value_cents: 400_00, admin:, common_area_id: 2, condo_id: 1, created_at: 2.days)
-      create(:common_area_fee, value_cents: 500_00, admin:, common_area_id: 2, condo_id: 1, created_at: 1.day)
+      create(:common_area_fee, value_cents: 200_00, admin:, common_area_id: 1, condo_id: 1,
+                               created_at: 2.days)
+      common_area_fee1 = create(:common_area_fee, value_cents: 300_00, admin:, common_area_id: 1, condo_id: 1,
+                                                  created_at: 1.day)
+      create(:common_area_fee, value_cents: 400_00, admin:, common_area_id: 2, condo_id: 1,
+                               created_at: 2.days)
+      common_area_fee2 = create(:common_area_fee, value_cents: 500_00, admin:, common_area_id: 2, condo_id: 1,
+                                                  created_at: 1.day)
 
       get api_v1_condo_common_area_fees_path(1)
 
@@ -59,10 +65,12 @@ describe 'API das Áreas Comuns' do
       expect(json_response[0]['value_cents']).to eq 300_00
       expect(json_response[0]['common_area_id']).to eq 1
       expect(json_response[0]['condo_id']).to eq 1
+      expect(json_response[0]['id']).to eq common_area_fee1.id
 
       expect(json_response[1]['value_cents']).to eq 500_00
       expect(json_response[1]['common_area_id']).to eq 2
       expect(json_response[1]['condo_id']).to eq 1
+      expect(json_response[1]['id']).to eq common_area_fee2.id
     end
   end
 


### PR DESCRIPTION
**CORREÇÃO DO ENDPOINT DE LISTAGEM DE COMMON_AREA_FEES** 


Foi adicionado o id de common_area_fee na listagem das taxas cadastradas mais recentes, para que o Time CondoMínions consiga utilizar essa informação ao chamar o segundo endpoint (de detalhes de uma common_area_fee)

---
**Endpoint 1:** 

`GET /api/v1/condos/:id/common_area_fees`

Recebe como parâmetro `:id` de um condomínio, e retorna uma lista com **a última taxa cadastrada para cada área comum desse condomínio**
Retorna:
Caso o condomínio não possua nenhuma taxa cadastrada: `status: 200, json: []`
Caso o condomínio possua alguma taxa cadastrada: `status: 200, json:`
``` 
[ 
  {
    "id":1,
    "value_cents":20000,
    "created_at":"2024-07-11T21:09:13.019Z",
    "common_area_id":1,
    "condo_id":1,
  },
  {
    "id":2,
    "value_cents":30000,
    "created_at":"2024-07-11T21:09:13.024Z",
    "common_area_id":2,
    "condo_id":1
  },
  {
    "id":3,
    "value_cents":40000,
    "created_at":"2024-07-11T21:09:13.027Z",
    "common_area_id":3,
    "condo_id":1
  }
] 
```



**Endpoint 2:** 

`GET /api/v1/common_area_fees/:id`

Recebe como parâmetro o `:id` de uma taxa cadastrada e retorna **os detalhes da taxa de área comum** desejada
Retorna:
Caso não exista taxa com o id informado: `status: 404, json: { "errors":"Não encontrado" } `
Caso o condomínio possua alguma taxa cadastrada: `status: 200, json:`
``` 
{
  "value_cents":20000,
  "created_at":"2024-07-11T21:09:13.019Z",
  "common_area_id":1,
  "condo_id":1
} 
```
