### PR TITLE
Cancelamento de taxas condominiais e cobranças avulsas

### DIFF
--- a/app/controllers/base_fees_controller.rb
+++ b/app/controllers/base_fees_controller.rb
@@ -1,6 +1,6 @@
 class BaseFeesController < ApplicationController
   before_action :authenticate_admin!
-  before_action :set_condo, only: [:new, :create, :index]
+  before_action :set_condo, only: [:new, :create, :index, :cancel]
 
   def index
     @base_fees = BaseFee.where(condo_id: @condo.id)
@@ -29,6 +29,12 @@ class BaseFeesController < ApplicationController
       flash.now[:alert] = I18n.t 'fail_notice_base_fee'
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def cancel
+    @base_fee = BaseFee.find(params[:id])
+    @base_fee.canceled!
+    redirect_to condo_base_fees_path(@condo.id), notice: "#{@base_fee.name} cancelada com sucesso."
   end
 
   private

--- a/app/controllers/single_charges_controller.rb
+++ b/app/controllers/single_charges_controller.rb
@@ -1,6 +1,6 @@
 class SingleChargesController < ApplicationController
   before_action :authenticate_admin!
-  before_action :set_condo, only: [:index, :show, :new, :create]
+  before_action :set_condo, only: [:index, :show, :new, :create, :cancel]
   before_action :set_common_areas, only: [:new, :create]
 
   def index
@@ -29,6 +29,12 @@ class SingleChargesController < ApplicationController
       flash.now[:alert] = I18n.t('fail_notice_single_charge')
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def cancel
+    @single_charge = SingleCharge.find(params[:id])
+    @single_charge.canceled!
+    redirect_to condo_single_charges_path(@condo.id), notice: "#{@single_charge.charge_type} cancelada com sucesso."
   end
 
   private

--- a/app/models/base_fee.rb
+++ b/app/models/base_fee.rb
@@ -9,6 +9,11 @@ class BaseFee < ApplicationRecord
   validate :installments_apply?
   validates :installments, numericality: { greater_than: 0, allow_nil: true }
 
+  enum status: {
+    active: 0,
+    canceled: 5
+  }
+
   monetize :late_fine_cents,
            allow_nil: false,
            numericality: {

--- a/app/models/single_charge.rb
+++ b/app/models/single_charge.rb
@@ -7,6 +7,11 @@ class SingleCharge < ApplicationRecord
 
   before_create :common_area_restriction
 
+  enum status: {
+    active: 0,
+    canceled: 5
+  }
+
   monetize :value_cents,
            allow_nil: false,
            numericality: {

--- a/app/views/base_fees/index.html.erb
+++ b/app/views/base_fees/index.html.erb
@@ -22,9 +22,9 @@
                   <%= I18n.l(base_fee.charge_day.to_date)%>
                 </small>
                 <% if base_fee.active? %>
-                  <span class="mt-1 ms-auto badge text-bg-success text-uppercase"><%= I18n.t("shared_fee.statuses.#{base_fee.status}") %></span>
+                  <span class="mt-1 ms-auto badge text-bg-success text-uppercase"><%= I18n.t("base_fee.statuses.#{base_fee.status}") %></span>
                 <% else %>
-                  <span class="mt-1 ms-auto badge text-bg-danger text-uppercase"><%= I18n.t("shared_fee.statuses.#{base_fee.status}") %></span>
+                  <span class="mt-1 ms-auto badge text-bg-danger text-uppercase"><%= I18n.t("base_fee.statuses.#{base_fee.status}") %></span>
                 <% end %>
               </div>
             </div>

--- a/app/views/base_fees/index.html.erb
+++ b/app/views/base_fees/index.html.erb
@@ -16,10 +16,17 @@
               <span class="d-block mb-1 fs-5">
                 <%= base_fee.name %>
               </span>
-              <small class="d-block text-body-secondary">
-                <%= SharedFee.human_attribute_name(:issue_date) %>:
-                <%= I18n.l(base_fee.charge_day.to_date)%>
-              </small>
+              <div class="d-flex flex-wrap text-end">
+                <small class="d-block text-body-secondary w-100">
+                  <%= SharedFee.human_attribute_name(:issue_date) %>:
+                  <%= I18n.l(base_fee.charge_day.to_date)%>
+                </small>
+                <% if base_fee.active? %>
+                  <span class="mt-1 ms-auto badge text-bg-success text-uppercase"><%= I18n.t("shared_fee.statuses.#{base_fee.status}") %></span>
+                <% else %>
+                  <span class="mt-1 ms-auto badge text-bg-danger text-uppercase"><%= I18n.t("shared_fee.statuses.#{base_fee.status}") %></span>
+                <% end %>
+              </div>
             </div>
             <span class="d-block">
               <%= base_fee.description %>

--- a/app/views/base_fees/show.html.erb
+++ b/app/views/base_fees/show.html.erb
@@ -7,6 +7,16 @@
     <span class="fs-8 text-center d-block"><%= @base_fee.description %></span>
     <hr>
 
+    <div class="d-flex justify-content-center align-items-center">
+      <% if @base_fee.active? %>
+        <span class="badge text-bg-success fs-4 text-uppercase ls-4"><%= I18n.t("shared_fee.statuses.#{@base_fee.status}") %></span>
+      <% else %>
+        <span class="badge text-bg-danger fs-4 text-uppercase ls-4"><%= I18n.t("shared_fee.statuses.#{@base_fee.status}") %></span>
+      <% end %>
+    </div>
+
+    <hr>
+
     <div class="d-flex justify-content-center align-items-center mb-2">
       <span class="badge text-bg-secondary fs-6 text-uppercase ls-4">
         <%= I18n.t("activerecord.attributes.base_fee.enum_recurrence.#{@base_fee.recurrence}") %>
@@ -66,6 +76,14 @@
         <%= I18n.l(@base_fee.charge_day.to_date)%>
       </span>
     </div>
+
+    <% if @base_fee.active? %>
+    <hr>
+      <%= button_to cancel_condo_base_fee_path(@condo.id, @base_fee), class: "d-flex align-items-center btn hover-danger mx-auto", data: { turbo_confirm: I18n.t('confirm-cancel') } do %>
+        <%= image_tag "block-icon", size: "16" %>
+        <span class="ms-1 fs-7 text-uppercase"><%= I18n.t('cancel-button') %></span>
+      <% end %>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/base_fees/show.html.erb
+++ b/app/views/base_fees/show.html.erb
@@ -9,9 +9,9 @@
 
     <div class="d-flex justify-content-center align-items-center">
       <% if @base_fee.active? %>
-        <span class="badge text-bg-success fs-4 text-uppercase ls-4"><%= I18n.t("shared_fee.statuses.#{@base_fee.status}") %></span>
+        <span class="badge text-bg-success fs-4 text-uppercase ls-4"><%= I18n.t("base_fee.statuses.#{@base_fee.status}") %></span>
       <% else %>
-        <span class="badge text-bg-danger fs-4 text-uppercase ls-4"><%= I18n.t("shared_fee.statuses.#{@base_fee.status}") %></span>
+        <span class="badge text-bg-danger fs-4 text-uppercase ls-4"><%= I18n.t("base_fee.statuses.#{@base_fee.status}") %></span>
       <% end %>
     </div>
 

--- a/app/views/shared_fees/show.html.erb
+++ b/app/views/shared_fees/show.html.erb
@@ -30,7 +30,7 @@
 
     <% if @shared_fee.active? %>
     <hr>
-      <%= button_to cancel_condo_shared_fee_path(@condo.id, @shared_fee), class: "d-flex align-items-center btn hover-danger mx-auto", data: { turbo_confirm: "Tem certeza que deseja cancelar essa conta compartilhada? Essa ação não poderá ser desfeita." } do %>
+      <%= button_to cancel_condo_shared_fee_path(@condo.id, @shared_fee), class: "d-flex align-items-center btn hover-danger mx-auto", data: { turbo_confirm: I18n.t('confirm-cancel') } do %>
         <%= image_tag "block-icon", size: "16" %>
         <span class="ms-1 fs-7 text-uppercase"><%= I18n.t('cancel-button') %></span>
       <% end %>

--- a/app/views/single_charges/index.html.erb
+++ b/app/views/single_charges/index.html.erb
@@ -26,6 +26,11 @@
                   <%= SingleCharge.human_attribute_name(:issue_date) %>:
                   <%= I18n.l(single_charge.issue_date) %>
                 </small>
+                <% if single_charge.active? %>
+                  <span class="mt-1 ms-auto badge text-bg-success text-uppercase"><%= I18n.t("single_charge.statuses.#{single_charge.status}") %></span>
+                <% else %>
+                  <span class="mt-1 ms-auto badge text-bg-danger text-uppercase"><%= I18n.t("single_charge.statuses.#{single_charge.status}") %></span>
+                <% end %>
               </div>
             </div>
             <span class="text-muted fs-7 text-lowercase"><%= SingleCharge.human_attribute_name(:value) %></span>

--- a/app/views/single_charges/index.html.erb
+++ b/app/views/single_charges/index.html.erb
@@ -5,6 +5,7 @@
   <span class="fs-4 mx-auto mt-3 text-uppercase">
     <%= SingleCharge.model_name.human(count: 2) %>
   </span>
+  <span class="mx-auto text-uppercase fs-7 text-muted"><%= @condo.name %></span>
   <div class="d-flex justify-content-center mt-4 mb-4">
     <% if @single_charges.any? %>
       <div class="list-group w-75">

--- a/app/views/single_charges/show.html.erb
+++ b/app/views/single_charges/show.html.erb
@@ -8,6 +8,16 @@
                 <%= Unit.find(@single_charge.unit_id).identifier %>
      </span>
     <hr>
+
+    <div class="d-flex justify-content-center align-items-center">
+      <% if @single_charge.active? %>
+        <span class="badge text-bg-success fs-4 text-uppercase ls-4"><%= I18n.t("single_charge.statuses.#{@single_charge.status}") %></span>
+      <% else %>
+        <span class="badge text-bg-danger fs-4 text-uppercase ls-4"><%= I18n.t("single_charge.statuses.#{@single_charge.status}") %></span>
+      <% end %>
+    </div>
+
+    <hr>
     <span class="fs-6 text-center d-block"><%= I18n.t 'activerecord.attributes.single_charge.charge_type' %>:</span>
     <span class="fs-4 text-center d-block"><%= I18n.t "single_charge.#{@single_charge.charge_type}" %></span>
     
@@ -39,6 +49,14 @@
         <%= I18n.l(@single_charge.issue_date.to_date) %>
       </span>
     </div>
+
+    <% if @single_charge.active? %>
+    <hr>
+      <%= button_to cancel_condo_single_charge_path(@condo.id, @single_charge), class: "d-flex align-items-center btn hover-danger mx-auto", data: { turbo_confirm: I18n.t('confirm-cancel') } do %>
+        <%= image_tag "block-icon", size: "16" %>
+        <span class="ms-1 fs-7 text-uppercase"><%= I18n.t('cancel-button') %></span>
+      <% end %>
+    <% end %>
 
   </div>
 <% end %>

--- a/config/locales/base_fees.pt-BR.yml
+++ b/config/locales/base_fees.pt-BR.yml
@@ -38,8 +38,10 @@ pt-BR:
             installments:
               not_limited_fee: não se aplica a Taxas Fixas
               is_limited_fee: deve estar presente para Taxas Limitadas
-
   base_fee:
+    statuses:
+      active: Ativa
+      canceled: Cancelada
     monthly: Mensal
     biweekly: Quinzenal
     bimonthly: Bimestral

--- a/config/locales/rails.pt-BR.yml
+++ b/config/locales/rails.pt-BR.yml
@@ -2,6 +2,7 @@ pt-BR:
   cancel-button: 'Cancelar'
   admin_description: para gerenciamento de condomínios e pagamentos
   property_description: para gerenciamento de seus imóveis
+  confirm-cancel: Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.
   activerecord:
     errors:
       messages:

--- a/config/locales/single_charge.pt-BR.yml
+++ b/config/locales/single_charge.pt-BR.yml
@@ -17,6 +17,9 @@ pt-BR:
         charge_type: Tipo de Cobrança
         common_area_id: Área Comum
   single_charge:
+    statuses:
+      active: Ativa
+      canceled: Cancelada
     common_area_fee: Taxa de Área Comum
     fine: Multa
     other: Outros

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
     resources :common_areas, only: [:index, :show] do
       resources :common_area_fees, only: [:new, :create]
     end
-    resources :base_fees, only: [:new, :create, :show, :index]
+    resources :base_fees, only: [:new, :create, :show, :index] do
+      post 'cancel', on: :member
+    end
 
     get 'search', on: :collection
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
       post 'cancel', on: :member
     end
 
-    resources :single_charges, only: [:show, :new, :create, :index]
+    resources :single_charges, only: [:show, :new, :create, :index] do
+      post 'cancel', on: :member
+    end
   end
 
   namespace :api do

--- a/db/migrate/20240716002312_add_status_to_base_fees.rb
+++ b/db/migrate/20240716002312_add_status_to_base_fees.rb
@@ -1,0 +1,5 @@
+class AddStatusToBaseFees < ActiveRecord::Migration[7.1]
+  def change
+    add_column :base_fees, :status, :integer, default: 0
+  end
+end

--- a/db/migrate/20240716004427_add_status_to_single_charges.rb
+++ b/db/migrate/20240716004427_add_status_to_single_charges.rb
@@ -1,0 +1,5 @@
+class AddStatusToSingleCharges < ActiveRecord::Migration[7.1]
+  def change
+    add_column :single_charges, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_11_200314) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_002312) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -76,6 +76,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_11_200314) do
     t.integer "recurrence", default: 0
     t.integer "condo_id"
     t.integer "installments"
+    t.integer "status", default: 0
   end
 
   create_table "bills", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_002312) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_004427) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -141,6 +141,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_002312) do
     t.integer "common_area_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "values", force: :cascade do |t|

--- a/spec/system/base_fees/admin_cancels_base_fee_spec.rb
+++ b/spec/system/base_fees/admin_cancels_base_fee_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe 'Admin cancela uma taxa condominial' do
+  it 'a partir da tela de detalhes de uma taxa condominial' do
+    admin = create(:admin)
+    condos = []
+    condos << Condo.new(id: 1, name: 'Prédio lindo', city: 'Cidade maravilhosa')
+    create(:base_fee, name: 'Taxa de Condomínio', condo_id: condos.first.id)
+    unit_types = []
+    unit_types << UnitType.new(id: 1, area: 30, description: 'Apartamento 1 quarto', ideal_fraction: 222.2, condo_id: 1)
+    allow(Condo).to receive(:all).and_return(condos)
+    allow(Condo).to receive(:find).and_return(condos.first)
+    allow(UnitType).to receive(:find_all_by_condo).and_return(unit_types)
+    allow(CommonArea).to receive(:all).and_return([])
+
+    login_as admin, scope: :admin
+    visit root_path
+    click_on 'Prédio lindo'
+    within 'div#base-fee' do
+      click_on 'Ver todas'
+    end
+    click_on 'Taxa de Condomínio'
+    accept_confirm 'Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.' do
+      click_button 'Cancelar'
+    end
+    base_fee = BaseFee.last
+
+    expect(page).to have_content "#{base_fee.name} cancelada com sucesso"
+    expect(base_fee.active?).to eq false
+    expect(base_fee.canceled?).to eq true
+    expect(current_path).to eq condo_base_fees_path(condos.first.id)
+    expect(page).to have_content 'CANCELADA'
+  end
+
+  it 'e não vê mais o botão de cancelar' do
+    admin = create(:admin)
+    condos = []
+    condos << Condo.new(id: 1, name: 'Prédio lindo', city: 'Cidade maravilhosa')
+    create(:base_fee, name: 'Taxa de Condomínio', condo_id: condos.first.id)
+    unit_types = []
+    unit_types << UnitType.new(id: 1, area: 30, description: 'Apartamento 1 quarto', ideal_fraction: 222.2, condo_id: 1)
+    allow(Condo).to receive(:all).and_return(condos)
+    allow(Condo).to receive(:find).and_return(condos.first)
+    allow(UnitType).to receive(:find_all_by_condo).and_return(unit_types)
+    allow(CommonArea).to receive(:all).and_return([])
+
+    login_as admin, scope: :admin
+    visit root_path
+    click_on 'Prédio lindo'
+    within 'div#base-fee' do
+      click_on 'Ver todas'
+    end
+    click_on 'Taxa de Condomínio'
+    accept_confirm 'Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.' do
+      click_button 'Cancelar'
+    end
+    click_on 'Taxa de Condomínio'
+
+    expect(page).to have_content 'CANCELADA'
+    expect(page).not_to have_button 'Cancelar'
+  end
+end

--- a/spec/system/shared_fees/admin_cancels_shared_fee_spec.rb
+++ b/spec/system/shared_fees/admin_cancels_shared_fee_spec.rb
@@ -25,7 +25,7 @@ describe 'Admin cancela uma conta compartilhada' do
       click_on 'Ver todas'
     end
     click_on 'Conta de Luz'
-    accept_confirm 'Tem certeza que deseja cancelar essa conta compartilhada? Essa ação não poderá ser desfeita.' do
+    accept_confirm 'Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.' do
       click_button 'Cancelar'
     end
     bill = SharedFee.last
@@ -61,7 +61,7 @@ describe 'Admin cancela uma conta compartilhada' do
       click_on 'Ver todas'
     end
     click_on 'Conta de Luz'
-    accept_confirm 'Tem certeza que deseja cancelar essa conta compartilhada? Essa ação não poderá ser desfeita.' do
+    accept_confirm 'Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.' do
       click_button 'Cancelar'
     end
     click_on 'Conta de Luz'
@@ -100,7 +100,7 @@ describe 'Admin cancela uma conta compartilhada' do
       click_on 'Ver todas'
     end
     click_on 'Conta de Luz'
-    accept_confirm 'Tem certeza que deseja cancelar essa conta compartilhada? Essa ação não poderá ser desfeita.' do
+    accept_confirm 'Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.' do
       click_button 'Cancelar'
     end
     electric_bill.reload

--- a/spec/system/shared_fees/admin_cancels_shared_fee_spec.rb
+++ b/spec/system/shared_fees/admin_cancels_shared_fee_spec.rb
@@ -66,7 +66,7 @@ describe 'Admin cancela uma conta compartilhada' do
     end
     click_on 'Conta de Luz'
 
-    expect(page).to have_content ''
+    expect(page).to have_content 'CANCELADA'
     expect(page).not_to have_button 'Cancelar'
   end
 

--- a/spec/system/single_charges/admin_cancels_single_charge_spec.rb
+++ b/spec/system/single_charges/admin_cancels_single_charge_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe 'Admin cancela uma cobrança avulsa' do
+  it 'a partir da tela de detalhes de uma cobrança avulsa' do
+    admin = create(:admin)
+    condos = []
+    condos << Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    unit_types = []
+    unit_types << UnitType.new(id: 1, area: 40, description: 'Apartamento 1 quarto', ideal_fraction: 0.3, condo_id: 1)
+    units = []
+    units << Unit.new(id: 1, area: 40, floor: 1, number: 1, unit_type_id: 1)
+    allow(Condo).to receive(:all).and_return(condos)
+    allow(Condo).to receive(:find).and_return(condos.first)
+    allow(UnitType).to receive(:all).and_return(unit_types)
+    allow(UnitType).to receive(:find).with(1).and_return(unit_types.first)
+    allow(Unit).to receive(:all).and_return(units)
+    allow(Unit).to receive(:find).with(1).and_return(units.first)
+    allow(CommonArea).to receive(:all).and_return([])
+    create(:single_charge, charge_type: 'fine', unit_id: 1)
+
+    login_as admin, scope: :admin
+    visit root_path
+    click_on 'Condo Test'
+    within '#single-charge' do
+      click_on 'Ver todas'
+    end
+    click_on 'Multa'
+    accept_confirm 'Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.' do
+      click_button 'Cancelar'
+    end
+    single_charge = SingleCharge.last
+
+    expect(page).to have_content "#{single_charge.charge_type} cancelada com sucesso"
+    expect(single_charge.active?).to eq false
+    expect(single_charge.canceled?).to eq true
+    expect(current_path).to eq condo_single_charges_path(condos.first.id)
+    expect(page).to have_content 'CANCELADA'
+  end
+
+  it 'e não vê mais o botão de cancelar' do
+    admin = create(:admin)
+    condos = []
+    condos << Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    unit_types = []
+    unit_types << UnitType.new(id: 1, area: 40, description: 'Apartamento 1 quarto', ideal_fraction: 0.3, condo_id: 1)
+    units = []
+    units << Unit.new(id: 1, area: 40, floor: 1, number: 1, unit_type_id: 1)
+    allow(Condo).to receive(:all).and_return(condos)
+    allow(Condo).to receive(:find).and_return(condos.first)
+    allow(UnitType).to receive(:all).and_return(unit_types)
+    allow(UnitType).to receive(:find).with(1).and_return(unit_types.first)
+    allow(Unit).to receive(:all).and_return(units)
+    allow(Unit).to receive(:find).with(1).and_return(units.first)
+    allow(CommonArea).to receive(:all).and_return([])
+    create(:single_charge, charge_type: 'fine', unit_id: 1)
+
+    login_as admin, scope: :admin
+    visit root_path
+    click_on 'Condo Test'
+    within '#single-charge' do
+      click_on 'Ver todas'
+    end
+    click_on 'Multa'
+    accept_confirm 'Tem certeza que deseja cancelar esse item? Essa ação não poderá ser desfeita.' do
+      click_button 'Cancelar'
+    end
+    click_on 'Multa'
+
+    expect(page).to have_content 'CANCELADA'
+    expect(page).not_to have_button 'Cancelar'
+  end
+end


### PR DESCRIPTION
Funcionalidade: Implementa a função de cancelamento (atribuição de status 'cancelado' via `enum`) para Taxas Condominiais (`base_fees`) e Cobranças Avulsas (`single_charges`).

O que foi feito: 
- [x] Testes de sistema para confirmar o cancelamento dos itens
- [x] Testes de sistema para garantir que só é possível cancelar cada item uma vez (o botão some)
- [x] Edição das telas de `index` e `show` para exibir os status

![Listagem de Taxas Condominiais](https://github.com/user-attachments/assets/7620ce19-4a32-4ea3-a991-3f33589633e1)
![Taxa Condominial Ativa](https://github.com/user-attachments/assets/94a124a9-ec0d-4257-8fbc-56b8b926c7b4)
![Taxa Condominial Cancelada](https://github.com/user-attachments/assets/613a3ec1-8528-4ffe-9c69-f6802f13d4a8)
![Listagem de Cobranças Avulsas](https://github.com/user-attachments/assets/67ac6c2e-143e-4997-ae63-5e9661022fd8)
![Cobrança Avulsa Ativa](https://github.com/user-attachments/assets/ae3db23f-9e85-48c0-90c2-e58d04684c61)
![Cobrança Avulsa Cancelada](https://github.com/user-attachments/assets/66d400ef-4417-4816-a3c6-f287435fa896)
