### PR TITLE
Endpoint de Listagem de Faturas pendentes de uma unidade

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Caso a unidade possua alguma taxa cadastrada: `status: 200`:
 
 Caso a unidade não possua nenhuma fatura cadastrada: `status: 200`:
 
-```
+```json
 {
   "bills": [
     

--- a/README.md
+++ b/README.md
@@ -342,7 +342,9 @@ Caso não exista taxa com o id informado: `status: 404`:
   "errors":"Não encontrado"
 }
 ```
-Caso o condomínio possua alguma taxa cadastrada: `status: 200`:
+
+Caso exista taxa com o id informado: `status: 200`:
+
 ```json
 {
   "unit_id": 1,
@@ -358,6 +360,40 @@ Caso o condomínio possua alguma taxa cadastrada: `status: 200`:
 }
 ```
 
+`GET api/v1/units/:unit_id/bills`
+
+Recebemos como parâmetro um `id` de uma fatura e retornamos **todos os detalhes da fatura** desejada. <br>
+**Retorna:** <br>
+
+Caso a unidade possua alguma taxa cadastrada: `status: 200`:
+```json
+{
+  "bills": [
+    {
+      "id": 1,
+      "issue_date": "2024-07-01",
+      "due_date": "2024-07-10",
+      "total_value_cents": 1000
+    },
+    {
+      "id": 3,
+      "issue_date": "2024-05-01",
+      "due_date": "2024-05-10",
+      "total_value_cents": 3000
+    }
+  ]
+}
+```
+
+Caso a unidade não possua nenhuma fatura cadastrada: `status: 200`:
+
+```
+{
+  "bills": [
+    
+  ]
+}
+```
 
 ## Desenvolvedores 🧑🏽‍💻🧑🏻‍💻🧑‍💻
 

--- a/app/controllers/api/v1/bills_controller.rb
+++ b/app/controllers/api/v1/bills_controller.rb
@@ -1,4 +1,11 @@
 class Api::V1::BillsController < Api::V1::ApiController
+  def index
+    unit_id = params[:unit_id]
+
+    bills = Bill.where(unit_id:, status: 'pending')
+    render status: :ok, json: { bills: bills.as_json(only: [:id, :issue_date, :due_date, :total_value_cents]) }
+  end
+
   def show
     id = params[:id]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
       resources :common_area_fees, only: [:show]
       resources :single_charges, only: [:create]
       resources :bills, only: [:show]
+      resources :units, only: [] do
+        resources :bills, only: [:index]
+      end
     end
   end
 

--- a/spec/requests/apis/bill_api_spec.rb
+++ b/spec/requests/apis/bill_api_spec.rb
@@ -46,4 +46,62 @@ describe 'API de Faturas' do
       expect(response).to have_http_status :not_found
     end
   end
+
+  context 'GET /api/v1/units/:unit_id/bills' do
+    it 'sucesso' do
+      one_month_ago = 1.month.ago.beginning_of_month.to_date
+      two_month_ago = 2.months.ago.beginning_of_month.to_date
+      three_month_ago = 3.months.ago.beginning_of_month.to_date
+      four_month_ago = 4.months.ago.beginning_of_month.to_date
+
+      unit = Unit.new(id: 1, area: 100, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                      condo_name: 'Prédio lindo', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+      unit2 = Unit.new(id: 2, area: 100, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
+                       condo_name: 'Prédio lindo', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+
+      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: one_month_ago, due_date: one_month_ago + 10.days,
+                    shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
+                    status: 'pending')
+      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: two_month_ago, due_date: two_month_ago + 10.days,
+                    shared_fee_value_cents: 200_00, base_fee_value_cents: 300_00, total_value_cents: 500_00,
+                    status: 'pending')
+      create(:bill, condo_id: 1, unit_id: unit2.id, issue_date: two_month_ago, due_date: two_month_ago + 10.days,
+                    shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
+                    status: 'pending')
+      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: three_month_ago, due_date: three_month_ago + 10.days,
+                    shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
+                    status: 'awaiting')
+      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: four_month_ago, due_date: four_month_ago + 10.days,
+                    shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
+                    status: 'paid')
+
+      get api_v1_unit_bills_path(unit.id)
+
+      expect(response).to have_http_status :ok
+      expect(response.content_type).to include 'application/json'
+      json_response = response.parsed_body
+      expect(json_response['bills'].count).to eq 2
+      expect(json_response['bills'].first['id']).to eq 1
+      expect(json_response['bills'].first['issue_date']).to eq one_month_ago.strftime('%Y-%m-%d')
+      expect(json_response['bills'].first['due_date']).to eq (one_month_ago + 10.days).strftime('%Y-%m-%d')
+      expect(json_response['bills'].first['total_value_cents']).to eq 400_00
+      expect(json_response['bills'].last['id']).to eq 2
+      expect(json_response['bills'].last['issue_date']).to eq two_month_ago.strftime('%Y-%m-%d')
+      expect(json_response['bills'].last['due_date']).to eq (two_month_ago + 10.days).strftime('%Y-%m-%d')
+      expect(json_response['bills'].last['total_value_cents']).to eq 500_00
+    end
+
+    it 'sucesso mesmo quando nao existem faturas' do
+      units = []
+      units << Unit.new(id: 1, area: 100, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                        condo_name: 'Prédio lindo', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+
+      get api_v1_unit_bills_path(units.first.id)
+
+      expect(response).to have_http_status :ok
+      expect(response.content_type).to include 'application/json'
+      json_response = response.parsed_body
+      expect(json_response['bills']).to be_empty
+    end
+  end
 end

--- a/spec/requests/apis/bill_api_spec.rb
+++ b/spec/requests/apis/bill_api_spec.rb
@@ -50,9 +50,9 @@ describe 'API de Faturas' do
   context 'GET /api/v1/units/:unit_id/bills' do
     it 'sucesso' do
       one_month_ago = 1.month.ago.beginning_of_month.to_date
-      two_month_ago = 2.months.ago.beginning_of_month.to_date
-      three_month_ago = 3.months.ago.beginning_of_month.to_date
-      four_month_ago = 4.months.ago.beginning_of_month.to_date
+      two_months_ago = 2.months.ago.beginning_of_month.to_date
+      three_months_ago = 3.months.ago.beginning_of_month.to_date
+      four_months_ago = 4.months.ago.beginning_of_month.to_date
 
       unit = Unit.new(id: 1, area: 100, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
                       condo_name: 'Prédio lindo', tenant_id: 1, owner_id: 1, description: 'Com varanda')
@@ -62,16 +62,16 @@ describe 'API de Faturas' do
       create(:bill, condo_id: 1, unit_id: unit.id, issue_date: one_month_ago, due_date: one_month_ago + 10.days,
                     shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
                     status: 'pending')
-      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: two_month_ago, due_date: two_month_ago + 10.days,
+      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: two_months_ago, due_date: two_months_ago + 10.days,
                     shared_fee_value_cents: 200_00, base_fee_value_cents: 300_00, total_value_cents: 500_00,
                     status: 'pending')
-      create(:bill, condo_id: 1, unit_id: unit2.id, issue_date: two_month_ago, due_date: two_month_ago + 10.days,
+      create(:bill, condo_id: 1, unit_id: unit2.id, issue_date: two_months_ago, due_date: two_months_ago + 10.days,
                     shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
                     status: 'pending')
-      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: three_month_ago, due_date: three_month_ago + 10.days,
+      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: three_months_ago, due_date: three_months_ago + 10.days,
                     shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
                     status: 'awaiting')
-      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: four_month_ago, due_date: four_month_ago + 10.days,
+      create(:bill, condo_id: 1, unit_id: unit.id, issue_date: four_months_ago, due_date: four_months_ago + 10.days,
                     shared_fee_value_cents: 100_00, base_fee_value_cents: 300_00, total_value_cents: 400_00,
                     status: 'paid')
 
@@ -86,8 +86,8 @@ describe 'API de Faturas' do
       expect(json_response['bills'].first['due_date']).to eq (one_month_ago + 10.days).strftime('%Y-%m-%d')
       expect(json_response['bills'].first['total_value_cents']).to eq 400_00
       expect(json_response['bills'].last['id']).to eq 2
-      expect(json_response['bills'].last['issue_date']).to eq two_month_ago.strftime('%Y-%m-%d')
-      expect(json_response['bills'].last['due_date']).to eq (two_month_ago + 10.days).strftime('%Y-%m-%d')
+      expect(json_response['bills'].last['issue_date']).to eq two_months_ago.strftime('%Y-%m-%d')
+      expect(json_response['bills'].last['due_date']).to eq (two_months_ago + 10.days).strftime('%Y-%m-%d')
       expect(json_response['bills'].last['total_value_cents']).to eq 500_00
     end
 


### PR DESCRIPTION
O que foi feito:
- Endpoint para listagem de faturas pendentes de uma unidade (/api/v1/units/:unit_id/bills)
- Testes para cobertura do novo endpoint
- Atualização no README

Encontra faturas (status 200):
```json
{
  "bills": [
    {
      "id": 1,
      "issue_date": "2024-07-01",
      "due_date": "2024-07-10",
      "total_value_cents": 1000
    },
    {
      "id": 3,
      "issue_date": "2024-05-01",
      "due_date": "2024-05-10",
      "total_value_cents": 3000
    }
  ]
}
```

Não encontra faturas (status 200):
```json
{
  "bills": [
    
  ]
}
```