### PR TITLE
 Garantir que fatura tenha um status

### DIFF
--- a/db/migrate/20240719001429_delete_status_from_bills.rb
+++ b/db/migrate/20240719001429_delete_status_from_bills.rb
@@ -1,0 +1,5 @@
+class DeleteStatusFromBills < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :bills, :status, :integer
+  end
+end

--- a/db/migrate/20240719001655_add_status_column_to_bills.rb
+++ b/db/migrate/20240719001655_add_status_column_to_bills.rb
@@ -1,0 +1,5 @@
+class AddStatusColumnToBills < ActiveRecord::Migration[7.1]
+  def change
+    add_column :bills, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_020443) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_19_001655) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -88,9 +88,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_020443) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "condo_id", null: false
-    t.integer "status", default: 0
     t.integer "shared_fee_value_cents"
     t.integer "base_fee_value_cents"
+    t.integer "status", default: 0, null: false
   end
 
   create_table "common_area_fees", force: :cascade do |t|

--- a/spec/models/bill_spec.rb
+++ b/spec/models/bill_spec.rb
@@ -9,4 +9,12 @@ RSpec.describe Bill, type: :model do
     it { should validate_presence_of(:base_fee_value_cents) }
     it { should validate_presence_of(:condo_id) }
   end
+
+  describe 'status' do
+    it 'deve ser criado por padrão com o status pendente' do
+      bill = Bill.new
+
+      expect(bill.status).to eq 'pending'
+    end
+  end
 end


### PR DESCRIPTION
O que foi feito: 
- Garante que ao ser criado, o model **BILL**  inicia com o status = 'pending', adicionando ao atributo `null: false, default: 0`
- Implementa teste de model que garante esse comportamento