### PR TITLE
Protege rotas de BaseFees e Bills

### DIFF
--- a/app/controllers/base_fees_controller.rb
+++ b/app/controllers/base_fees_controller.rb
@@ -1,5 +1,6 @@
 class BaseFeesController < ApplicationController
   before_action :authenticate_admin!
+  before_action :admin_authorized?
   before_action :set_condo, only: [:new, :create, :index, :cancel]
 
   def index

--- a/app/controllers/base_fees_controller.rb
+++ b/app/controllers/base_fees_controller.rb
@@ -1,7 +1,7 @@
 class BaseFeesController < ApplicationController
   before_action :authenticate_admin!
   before_action :admin_authorized?
-  before_action :set_condo, only: [:new, :create, :index, :cancel]
+  before_action :set_condo, except: [:show]
 
   def index
     @base_fees = BaseFee.where(condo_id: @condo.id).order(charge_day: :desc)

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -1,7 +1,8 @@
 class BillsController < ApplicationController
-  before_action :set_condo, only: [:index, :show, :accept_payment, :reject_payment]
-  before_action :set_bill, only: [:show, :accept_payment, :reject_payment]
-  before_action :admin_authorized?, only: [:accept_payment, :reject_payment]
+  before_action :set_condo
+  before_action :set_bill, except: [:index]
+  before_action :admin_authorized?
+  before_action :bill_belongs_to_condo, only: [:show]
 
   def index
     @bills = Bill.where(condo_id: @condo.id)
@@ -13,16 +14,22 @@ class BillsController < ApplicationController
 
   def accept_payment
     @bill.paid!
-    redirect_to condo_bills_path(@condo), notice: I18n.t('views.index.payment_accepted')
+    redirect_to condo_bills_path(@condo.id), notice: I18n.t('views.index.payment_accepted')
   end
 
   def reject_payment
     @bill.pending!
     @bill.receipt.destroy
-    redirect_to condo_bills_path(@condo), notice: I18n.t('views.index.payment_rejected')
+    redirect_to condo_bills_path(@condo.id), notice: I18n.t('views.index.payment_rejected')
   end
 
   private
+
+  def bill_belongs_to_condo
+    return if @bill.condo_id == @condo.id
+
+    redirect_to condo_bills_path(@condo.id), notice: I18n.t('views.index.no_bills')
+  end
 
   def set_bill
     @bill = Bill.find(params[:id])

--- a/app/controllers/common_area_fees_controller.rb
+++ b/app/controllers/common_area_fees_controller.rb
@@ -1,6 +1,6 @@
 class CommonAreaFeesController < ApplicationController
   before_action :authenticate_admin!
-  before_action :admin_authorized?, only: [:new, :create]
+  before_action :admin_authorized?
   before_action :set_common_area, only: [:new, :create]
 
   def new

--- a/app/controllers/common_area_fees_controller.rb
+++ b/app/controllers/common_area_fees_controller.rb
@@ -1,7 +1,7 @@
 class CommonAreaFeesController < ApplicationController
   before_action :authenticate_admin!
   before_action :admin_authorized?
-  before_action :set_common_area, only: [:new, :create]
+  before_action :set_common_area
 
   def new
     @common_area_fee = CommonAreaFee.new

--- a/app/controllers/common_areas_controller.rb
+++ b/app/controllers/common_areas_controller.rb
@@ -1,7 +1,7 @@
 class CommonAreasController < ApplicationController
   before_action :authenticate_admin!
   before_action :admin_authorized?
-  before_action :find_condo, only: [:index, :show]
+  before_action :find_condo
   before_action :find_common_area, only: [:show]
 
   def index

--- a/app/controllers/common_areas_controller.rb
+++ b/app/controllers/common_areas_controller.rb
@@ -1,6 +1,6 @@
 class CommonAreasController < ApplicationController
   before_action :authenticate_admin!
-  before_action :admin_authorized?, only: [:index, :show]
+  before_action :admin_authorized?
   before_action :find_condo, only: [:index, :show]
   before_action :find_common_area, only: [:show]
 

--- a/spec/requests/base_fees/admin_access_base_fee_details_spec.rb
+++ b/spec/requests/base_fees/admin_access_base_fee_details_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe 'Admin acessa detalhes de uma taxa condominial' do
+  it 'com sucesso - super admin' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: true)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    unit_type = UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 100, fraction: 1.0,
+                             unit_ids: [])
+    base_fee = create(:base_fee, condo_id: condo.id)
+
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(UnitType).to receive(:all).and_return([unit_type])
+
+    login_as admin, scope: :admin
+    get condo_base_fee_path(condo.id, base_fee.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Taxa de Condomínio'
+    expect(response.body).to include 'Manutenção geral do condomínio.'
+  end
+
+  it 'com sucesso - Admin associado ao condominio' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    unit_type = UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 100, fraction: 1.0,
+                             unit_ids: [])
+    base_fee = create(:base_fee, condo_id: condo.id)
+    AssociatedCondo.create(admin_id: admin.id, condo_id: condo.id)
+
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(UnitType).to receive(:all).and_return([unit_type])
+
+    login_as admin, scope: :admin
+    get condo_base_fee_path(condo.id, base_fee.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Taxa de Condomínio'
+    expect(response.body).to include 'Manutenção geral do condomínio.'
+  end
+
+  it 'falha pois não está associado' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    unit_type = UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 100, fraction: 1.0,
+                             unit_ids: [])
+    base_fee = create(:base_fee, condo_id: condo.id)
+
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(UnitType).to receive(:all).and_return([unit_type])
+
+    login_as admin, scope: :admin
+    get condo_base_fee_path(condo.id, base_fee.id)
+
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to root_path
+    expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
+  end
+end

--- a/spec/requests/base_fees/admin_access_index_base_fees_spec.rb
+++ b/spec/requests/base_fees/admin_access_index_base_fees_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'Admin acessa lista de taxas condominiais' do
+  it 'com sucesso - super admin' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: true)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    allow(Condo).to receive(:find).and_return(condo)
+    create(:base_fee, name: 'Fundo de Reserva', description: 'Destinado a cobrir despesas imprevistas',
+                      recurrence: :monthly, charge_day: 10.days.from_now, condo_id: condo.id)
+    create(:base_fee, name: 'Jardinagem', description: 'Cuidar das arvores do condomínio',
+                      recurrence: :bimonthly, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    get condo_base_fees_path(condo.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Listagem de Taxas Condominiais'
+    expect(response.body).to include 'Condo Test'
+    expect(response.body).to include 'TODAS AS TAXAS'
+    expect(response.body).to include 'Fundo de Reserva'
+    expect(response.body).to include 'Destinado a cobrir despesas imprevistas'
+    expect(response.body).to include 'Recorrência'
+    expect(response.body).to include 'Mensal'
+    expect(response.body).to include 'Jardinagem'
+    expect(response.body).to include 'Cuidar das arvores do condomínio'
+    expect(response.body).to include 'Bimestral'
+  end
+
+  it 'com sucesso - Admin com acesso' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    allow(Condo).to receive(:find).and_return(condo)
+    create(:base_fee, name: 'Fundo de Reserva', description: 'Destinado a cobrir despesas imprevistas',
+                      recurrence: :monthly, charge_day: 10.days.from_now, condo_id: condo.id)
+    create(:base_fee, name: 'Jardinagem', description: 'Cuidar das arvores do condomínio',
+                      recurrence: :bimonthly, condo_id: condo.id)
+    AssociatedCondo.create(admin_id: admin.id, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    get condo_base_fees_path(condo.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Listagem de Taxas Condominiais'
+    expect(response.body).to include 'Condo Test'
+    expect(response.body).to include 'TODAS AS TAXAS'
+    expect(response.body).to include 'Fundo de Reserva'
+    expect(response.body).to include 'Destinado a cobrir despesas imprevistas'
+    expect(response.body).to include 'Recorrência'
+    expect(response.body).to include 'Mensal'
+    expect(response.body).to include 'Jardinagem'
+    expect(response.body).to include 'Cuidar das arvores do condomínio'
+    expect(response.body).to include 'Bimestral'
+  end
+
+  it 'falha pois não está associado' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+
+    allow(Condo).to receive(:find).and_return(condo)
+
+    login_as admin, scope: :admin
+    get condo_base_fees_path(condo.id)
+
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to root_path
+    expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
+  end
+end

--- a/spec/requests/base_fees/admin_access_new_base_fees_spec.rb
+++ b/spec/requests/base_fees/admin_access_new_base_fees_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe 'Admin cria taxa condominial' do
+  it 'com sucesso' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: true)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(UnitType).to receive(:all).and_return([])
+
+    login_as admin, scope: :admin
+    get new_condo_base_fee_path(condo.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Cadastro'
+    expect(response.body).to include 'Condo Test'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.name'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.description'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.interest_rate'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.late_fine'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.charge_day'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.limited'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.installments'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.recurrence'
+  end
+
+  it 'com sucesso - Admin com acesso' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(UnitType).to receive(:all).and_return([])
+    AssociatedCondo.create(admin:, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    get new_condo_base_fee_path(condo.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Cadastro'
+    expect(response.body).to include 'Condo Test'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.name'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.description'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.interest_rate'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.late_fine'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.charge_day'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.limited'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.installments'
+    expect(response.body).to include I18n.t 'activerecord.attributes.base_fee.recurrence'
+  end
+
+  it 'falha pois não está associado' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(UnitType).to receive(:all).and_return([])
+
+    login_as admin, scope: :admin
+    get new_condo_base_fee_path(condo.id)
+
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to root_path
+    expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
+  end
+end

--- a/spec/requests/base_fees/admin_access_new_base_fees_spec.rb
+++ b/spec/requests/base_fees/admin_access_new_base_fees_spec.rb
@@ -4,7 +4,6 @@ describe 'Admin cria taxa condominial' do
   it 'com sucesso' do
     admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: true)
     condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
-
     allow(Condo).to receive(:find).and_return(condo)
     allow(UnitType).to receive(:all).and_return([])
 

--- a/spec/requests/base_fees/admin_cancels_base_fee_spec.rb
+++ b/spec/requests/base_fees/admin_cancels_base_fee_spec.rb
@@ -4,7 +4,11 @@ describe 'Admin cancela uma taxa condominial' do
   it 'com sucesso - super admin' do
     admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: true)
     condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    unit = Unit.new(id: 1, area: 40, floor: 3, number: '31', unit_type_id: 1, condo_id: condo.id,
+                    condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
     base_fee = create(:base_fee, condo_id: condo.id)
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(Unit).to receive(:find).and_return(unit)
 
     login_as admin, scope: :admin
     post cancel_condo_base_fee_path(condo.id, base_fee.id)
@@ -17,6 +21,10 @@ describe 'Admin cancela uma taxa condominial' do
     admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
     condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
     base_fee = create(:base_fee, condo_id: condo.id)
+    unit = Unit.new(id: 1, area: 40, floor: 3, number: '31', unit_type_id: 1, condo_id: condo.id,
+                    condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(Unit).to receive(:find).and_return(unit)
     AssociatedCondo.create(admin_id: admin.id, condo_id: condo.id)
 
     login_as admin, scope: :admin

--- a/spec/requests/base_fees/admin_cancels_base_fee_spec.rb
+++ b/spec/requests/base_fees/admin_cancels_base_fee_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'Admin cancela uma taxa condominial' do
+  it 'com sucesso - super admin' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: true)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    base_fee = create(:base_fee, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    post cancel_condo_base_fee_path(condo.id, base_fee.id)
+
+    expect(response).to have_http_status :found
+    expect(flash[:notice]).to eq "#{base_fee.name} cancelada com sucesso."
+  end
+
+  it 'com sucesso - Admin associado ao condominio' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    base_fee = create(:base_fee, condo_id: condo.id)
+    AssociatedCondo.create(admin_id: admin.id, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    post cancel_condo_base_fee_path(condo.id, base_fee.id)
+
+    expect(response).to have_http_status :found
+    expect(flash[:notice]).to eq "#{base_fee.name} cancelada com sucesso."
+  end
+
+  it 'falha pois não está associado' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    base_fee = create(:base_fee, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    post cancel_condo_base_fee_path(condo.id, base_fee.id)
+
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to root_path
+    expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
+  end
+end

--- a/spec/requests/base_fees/admin_creates_base_fees_spec.rb
+++ b/spec/requests/base_fees/admin_creates_base_fees_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-describe 'Admin creates a base fee' do
-  it 'successfully' do
-    admin = create(:admin, email: 'admin@email.com', password: '123456')
+describe 'Admin cria taxa condominial' do
+  it 'com sucesso - super admin' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: true)
     condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
     unit_types = []
     unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 100, fraction: 1.0,
@@ -32,14 +32,54 @@ describe 'Admin creates a base fee' do
                                                                } } })
 
     expect(BaseFee.count).to eq 1
-    expect(response).to have_http_status(302)
-    expect(response).to redirect_to(condo_path(condo.id))
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to condo_path(condo.id)
     expect(BaseFee.last.description).to eq 'Descrição'
     expect(BaseFee.last.charge_day).to eq 10.days.from_now.to_date
     expect(BaseFee.last.values.count).to eq 2
   end
 
-  it 'and is not authenticated' do
+  it 'com sucesso - Admin com acesso' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
+    unit_types = []
+    unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 100, fraction: 1.0,
+                               unit_ids: [])
+    unit_types << UnitType.new(id: 2, description: 'Apartamento 2 quarto', metreage: 200, fraction: 2.0,
+                               unit_ids: [])
+
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(UnitType).to receive(:all).and_return(unit_types)
+    AssociatedCondo.create(admin:, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    post(condo_base_fees_path(condo.id), params: { base_fee: { name: 'Nome',
+                                                               description: 'Descrição',
+                                                               interest_rate: 2,
+                                                               late_fine: 30,
+                                                               charge_day: 10.days.from_now,
+                                                               condo_id: condo.id,
+                                                               values_attributes: {
+                                                                 '0': {
+                                                                   price: 100,
+                                                                   unit_type_id: unit_types.first.id
+                                                                 },
+                                                                 '1': {
+                                                                   price: 100,
+                                                                   unit_type_id: unit_types.last.id
+                                                                 }
+                                                               } } })
+
+    expect(BaseFee.count).to eq 1
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to condo_path(condo.id)
+    expect(BaseFee.last.description).to eq 'Descrição'
+    expect(BaseFee.last.charge_day).to eq 10.days.from_now.to_date
+    expect(BaseFee.last.values.count).to eq 2
+  end
+
+  it 'falha pois não está associado' do
+    admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
     condo = Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
     unit_types = []
     unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 100, fraction: 1.0,
@@ -50,6 +90,7 @@ describe 'Admin creates a base fee' do
     allow(Condo).to receive(:find).and_return(condo)
     allow(UnitType).to receive(:all).and_return(unit_types)
 
+    login_as admin, scope: :admin
     post(condo_base_fees_path(condo.id), params: { base_fee: { name: 'Nome',
                                                                description: 'Descrição',
                                                                late_payment: 2,
@@ -66,8 +107,9 @@ describe 'Admin creates a base fee' do
                                                                    unit_type_id: unit_types.last.id
                                                                  }
                                                                } } })
+
     expect(BaseFee.count).to eq 0
-    expect(response).to have_http_status(302)
-    expect(response).to redirect_to(new_admin_session_path)
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to root_path
   end
 end

--- a/spec/requests/bills/user_access_bills_details_spec.rb
+++ b/spec/requests/bills/user_access_bills_details_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+describe 'Usuario acessa uma fatura' do
+  it 'sucesso - super admin' do
+    admin = create(:admin, super_admin: true)
+    condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    unit = Unit.new(id: 1, area: 40, floor: 3, number: '31', unit_type_id: 1, condo_id: condo.id,
+                    condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(Unit).to receive(:find).and_return(unit)
+
+    bill = create(:bill, id: 1,
+                         unit_id: 97,
+                         issue_date: Time.zone.today,
+                         due_date: 10.days.from_now,
+                         total_value_cents: 3_100_00,
+                         condo_id: condo.id,
+                         shared_fee_value_cents: 2_100_00,
+                         base_fee_value_cents: 1_000_00,
+                         status: :pending)
+
+    login_as admin, scope: :admin
+    get condo_bill_path(condo.id, bill)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Fatura'
+    expect(response.body).to include 'Unidade 31'
+    expect(response.body).to include 'Condomínio Vila das Flores'
+    expect(response.body).to include 'valor total'
+    expect(response.body).to include 'R$3.100,00'
+    expect(response.body).to include 'Taxa Condominial'
+    expect(response.body).to include '0'
+    expect(response.body).to include 'Conta Compartilhada'
+    expect(response.body).to include 'data de vencimento'
+    expect(response.body).to include 'data de emissão'
+    expect(response.body).to include 'Pagamento'
+    expect(response.body).to include 'Pendente'
+  end
+
+  it 'sucesso - admin associado' do
+    admin = create(:admin, super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    unit = Unit.new(id: 1, area: 40, floor: 3, number: '31', unit_type_id: 1, condo_id: condo.id,
+                    condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(Unit).to receive(:find).and_return(unit)
+    AssociatedCondo.create!(admin_id: admin.id, condo_id: condo.id)
+
+    bill = create(:bill, id: 1,
+                         unit_id: 97,
+                         issue_date: Time.zone.today,
+                         due_date: 10.days.from_now,
+                         total_value_cents: 3_100_00,
+                         condo_id: condo.id,
+                         shared_fee_value_cents: 2_100_00,
+                         base_fee_value_cents: 1_000_00,
+                         status: :pending)
+
+    login_as admin, scope: :admin
+    get condo_bill_path(condo.id, bill)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include 'Fatura'
+    expect(response.body).to include 'Unidade 31'
+    expect(response.body).to include 'Condomínio Vila das Flores'
+    expect(response.body).to include 'valor total'
+    expect(response.body).to include 'R$3.100,00'
+    expect(response.body).to include 'Taxa Condominial'
+    expect(response.body).to include '0'
+    expect(response.body).to include 'Conta Compartilhada'
+    expect(response.body).to include 'data de vencimento'
+    expect(response.body).to include 'data de emissão'
+    expect(response.body).to include 'Pagamento'
+    expect(response.body).to include 'Pendente'
+  end
+
+  it 'erro - admin não associado' do
+    admin = create(:admin, super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    unit = Unit.new(id: 1, area: 40, floor: 3, number: '31', unit_type_id: 1, condo_id: condo.id,
+                    condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+    allow(Condo).to receive(:find).and_return(condo)
+    allow(Unit).to receive(:find).and_return(unit)
+
+    bill = create(:bill, id: 1,
+                         unit_id: 97,
+                         issue_date: Time.zone.today,
+                         due_date: 10.days.from_now,
+                         total_value_cents: 3_100_00,
+                         condo_id: condo.id,
+                         shared_fee_value_cents: 2_100_00,
+                         base_fee_value_cents: 1_000_00,
+                         status: :pending)
+
+    login_as admin, scope: :admin
+    get condo_bill_path(condo.id, bill)
+
+    expect(response).to have_http_status :found
+    expect(response.body).not_to include 'Fatura'
+    expect(response.body).not_to include 'Unidade 31'
+    expect(response.body).not_to include 'Condomínio Vila das Flores'
+    expect(response.body).not_to include 'valor total'
+    expect(response.body).not_to include 'R$3.100,00'
+  end
+
+  it 'falha pois tenta acessar fatura de outro condomínio' do
+    admin = create(:admin, super_admin: true)
+    condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    condo2 = Condo.new(id: 2, name: 'Condomínio Paraíso', city: 'São Paulo')
+    allow(Condo).to receive(:find).and_return(condo2)
+
+    bill = create(:bill,
+                  condo_id: condo.id,
+                  unit_id: 1,
+                  issue_date: Time.zone.today.beginning_of_month,
+                  due_date: 10.days.from_now,
+                  total_value_cents: 500_00,
+                  status: :pending)
+
+    login_as admin, scope: :admin
+    get condo_bill_path(condo2.id, bill)
+
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to condo_bills_path(condo2.id)
+    expect(flash[:notice]).to eq I18n.t('views.index.no_bills')
+  end
+end

--- a/spec/requests/bills/user_access_bills_list_spec.rb
+++ b/spec/requests/bills/user_access_bills_list_spec.rb
@@ -4,7 +4,10 @@ describe 'Usuario acessa lista de faturas do condominio' do
   it 'sucesso - super admin' do
     admin = create(:admin, super_admin: true)
     condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    unit = Unit.new(id: 1, area: 40, floor: 3, number: '31', unit_type_id: 1, condo_id: condo.id,
+                    condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
     allow(Condo).to receive(:find).and_return(condo)
+    allow(Unit).to receive(:find).and_return(unit)
 
     create(:bill,
            condo_id: condo.id,
@@ -35,7 +38,10 @@ describe 'Usuario acessa lista de faturas do condominio' do
   it 'sucesso - admin associado' do
     admin = create(:admin, super_admin: false)
     condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    unit = Unit.new(id: 1, area: 40, floor: 3, number: '31', unit_type_id: 1, condo_id: condo.id,
+                    condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
     allow(Condo).to receive(:find).and_return(condo)
+    allow(Unit).to receive(:find).and_return(unit)
 
     create(:bill,
            condo_id: condo.id,

--- a/spec/requests/bills/user_access_bills_list_spec.rb
+++ b/spec/requests/bills/user_access_bills_list_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+describe 'Usuario acessa lista de faturas do condominio' do
+  it 'sucesso - super admin' do
+    admin = create(:admin, super_admin: true)
+    condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    allow(Condo).to receive(:find).and_return(condo)
+
+    create(:bill,
+           condo_id: condo.id,
+           unit_id: 1,
+           issue_date: Time.zone.today.beginning_of_month,
+           due_date: 10.days.from_now,
+           total_value_cents: 500_00,
+           status: :pending)
+
+    create(:bill,
+           condo_id: condo.id,
+           unit_id: 1,
+           issue_date: Time.zone.today.beginning_of_month,
+           due_date: 10.days.from_now,
+           total_value_cents: 111_11,
+           status: :pending)
+
+    login_as admin, scope: :admin
+    get condo_bills_path(condo.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include('Condomínio Vila das Flores')
+    expect(response.body).to include('Fatura')
+    expect(response.body).to include('500,00')
+    expect(response.body).to include('111,11')
+  end
+
+  it 'sucesso - admin associado' do
+    admin = create(:admin, super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    allow(Condo).to receive(:find).and_return(condo)
+
+    create(:bill,
+           condo_id: condo.id,
+           unit_id: 1,
+           issue_date: Time.zone.today.beginning_of_month,
+           due_date: 10.days.from_now,
+           total_value_cents: 500_00,
+           status: :pending)
+
+    create(:bill,
+           condo_id: condo.id,
+           unit_id: 1,
+           issue_date: Time.zone.today.beginning_of_month,
+           due_date: 10.days.from_now,
+           total_value_cents: 111_11,
+           status: :pending)
+
+    AssociatedCondo.create!(admin_id: admin.id, condo_id: condo.id)
+
+    login_as admin, scope: :admin
+    get condo_bills_path(condo.id)
+
+    expect(response).to have_http_status :ok
+    expect(response.body).to include('Condomínio Vila das Flores')
+    expect(response.body).to include('Fatura')
+    expect(response.body).to include('500,00')
+    expect(response.body).to include('111,11')
+  end
+
+  it 'erro - admin não associado' do
+    admin = create(:admin, super_admin: false)
+    condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+    allow(Condo).to receive(:find).and_return(condo)
+
+    create(:bill,
+           condo_id: condo.id,
+           unit_id: 1,
+           issue_date: Time.zone.today.beginning_of_month,
+           due_date: 10.days.from_now,
+           total_value_cents: 500_00,
+           status: :pending)
+
+    login_as admin, scope: :admin
+    get condo_bills_path(condo.id)
+
+    expect(response).to have_http_status :found
+    expect(response).to redirect_to root_path
+    expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
+  end
+end

--- a/spec/requests/bills/user_tries_to_change_bill_status_spec.rb
+++ b/spec/requests/bills/user_tries_to_change_bill_status_spec.rb
@@ -1,5 +1,151 @@
 require 'rails_helper'
 
+describe 'usuário autenticado tenta mudar status de fatura' do
+  context 'super admin' do
+    it 'para pago - aceitando o pagamento' do
+      admin = create(:admin, super_admin: true)
+      condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+      unit_types = []
+      unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                 unit_ids: [])
+      units = []
+      units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+      allow(Condo).to receive(:find).and_return(condo)
+      allow(CommonArea).to receive(:all).and_return([])
+      allow(UnitType).to receive(:all).and_return(unit_types)
+      allow(Unit).to receive(:all).and_return(units)
+      allow(Unit).to receive(:find).and_return(units.first)
+
+      bill = create(
+        :bill,
+        condo_id: 1,
+        unit_id: units[0].id,
+        issue_date: Time.zone.today.beginning_of_month,
+        due_date: 10.days.from_now,
+        total_value_cents: 500_00,
+        status: :awaiting
+      )
+
+      login_as admin, scope: :admin
+
+      post accept_payment_condo_bill_path(condo.id, bill)
+
+      expect(response).to redirect_to condo_bills_path(condo.id)
+      expect(flash[:notice]).to eq I18n.t('views.index.payment_accepted')
+    end
+
+    it 'para pendente - recusando o pagamento' do
+      admin = create(:admin, super_admin: true)
+      condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+      unit_types = []
+      unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                 unit_ids: [])
+      units = []
+      units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+      allow(Condo).to receive(:find).and_return(condo)
+      allow(CommonArea).to receive(:all).and_return([])
+      allow(UnitType).to receive(:all).and_return(unit_types)
+      allow(Unit).to receive(:all).and_return(units)
+      allow(Unit).to receive(:find).and_return(units.first)
+
+      bill = create(
+        :bill,
+        condo_id: 1,
+        unit_id: units[0].id,
+        issue_date: Time.zone.today.beginning_of_month,
+        due_date: 10.days.from_now,
+        total_value_cents: 500_00,
+        status: :awaiting
+      )
+
+      bill.receipt = create(:receipt, bill_id: bill.id)
+
+      login_as admin, scope: :admin
+
+      post reject_payment_condo_bill_path(condo.id, bill)
+
+      expect(response).to redirect_to condo_bills_path(condo.id)
+      expect(flash[:notice]).to eq I18n.t('views.index.payment_rejected')
+    end
+  end
+
+  context 'admin associado' do
+    it 'para pago - aceitando o pagamento' do
+      admin = create(:admin, super_admin: false)
+      condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+      unit_types = []
+      unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                 unit_ids: [])
+      units = []
+      units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+      allow(Condo).to receive(:find).and_return(condo)
+      allow(CommonArea).to receive(:all).and_return([])
+      allow(UnitType).to receive(:all).and_return(unit_types)
+      allow(Unit).to receive(:all).and_return(units)
+      allow(Unit).to receive(:find).and_return(units.first)
+
+      AssociatedCondo.create(admin_id: admin.id, condo_id: condo.id)
+
+      bill = create(
+        :bill,
+        condo_id: 1,
+        unit_id: units[0].id,
+        issue_date: Time.zone.today.beginning_of_month,
+        due_date: 10.days.from_now,
+        total_value_cents: 500_00,
+        status: :awaiting
+      )
+
+      login_as admin, scope: :admin
+
+      post accept_payment_condo_bill_path(condo.id, bill)
+
+      expect(response).to redirect_to condo_bills_path(condo.id)
+      expect(flash[:notice]).to eq I18n.t('views.index.payment_accepted')
+    end
+
+    it 'para pendente - recusando o pagamento' do
+      admin = create(:admin, super_admin: false)
+      condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+      unit_types = []
+      unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                 unit_ids: [])
+      units = []
+      units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+      allow(Condo).to receive(:find).and_return(condo)
+      allow(CommonArea).to receive(:all).and_return([])
+      allow(UnitType).to receive(:all).and_return(unit_types)
+      allow(Unit).to receive(:all).and_return(units)
+      allow(Unit).to receive(:find).and_return(units.first)
+
+      AssociatedCondo.create(admin_id: admin.id, condo_id: condo.id)
+
+      bill = create(
+        :bill,
+        condo_id: 1,
+        unit_id: units[0].id,
+        issue_date: Time.zone.today.beginning_of_month,
+        due_date: 10.days.from_now,
+        total_value_cents: 500_00,
+        status: :awaiting
+      )
+
+      bill.receipt = create(:receipt, bill_id: bill.id)
+
+      login_as admin, scope: :admin
+
+      post reject_payment_condo_bill_path(condo.id, bill)
+
+      expect(response).to redirect_to condo_bills_path(condo.id)
+      expect(flash[:notice]).to eq I18n.t('views.index.payment_rejected')
+    end
+  end
+end
+
 describe 'usuário não autenticado tenta mudar status de fatura' do
   it 'para pago - aceitando o pagamento' do
     condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
@@ -30,6 +176,7 @@ describe 'usuário não autenticado tenta mudar status de fatura' do
     expect(response).to redirect_to root_path
     expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
   end
+
   it 'para pendente - recusando o pagamento' do
     condos = []
     condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
@@ -63,6 +210,7 @@ describe 'usuário não autenticado tenta mudar status de fatura' do
     expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
   end
 end
+
 describe 'administrador não associado ao condominio daquela fatura' do
   context 'tenta mudar status da fatura' do
     it 'para pago - aceitando o pagamento' do
@@ -97,6 +245,7 @@ describe 'administrador não associado ao condominio daquela fatura' do
       expect(response).to redirect_to root_path
       expect(flash[:notice]).to eq I18n.t('errors.messages.must_be_super_admin')
     end
+
     it 'para pendente - recusando o pagamento' do
       admin = create(:admin, super_admin: false)
       condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')

--- a/spec/requests/common_area_fee/admin_access_new_common_area_fee_spec.rb
+++ b/spec/requests/common_area_fee/admin_access_new_common_area_fee_spec.rb
@@ -20,7 +20,7 @@ describe 'Administrador acessa formulário de Taxa de área comum' do
     expect(response.body).to include 'Taxa'
   end
 
-  it 'sucesso - admin coom acesso' do
+  it 'sucesso - admin com acesso' do
     admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
     condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
     allow(Condo).to receive(:find).and_return(condo)
@@ -40,7 +40,7 @@ describe 'Administrador acessa formulário de Taxa de área comum' do
     expect(response.body).to include 'Taxa'
   end
 
-  it 'falha pois nao esta associad' do
+  it 'falha pois não está associado' do
     admin = create(:admin, email: 'admin@email.com', password: '123456', super_admin: false)
     condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
     allow(Condo).to receive(:find).and_return(condo)


### PR DESCRIPTION
Validações de autorização para as rotas:

base_fee:
- `new`
- `create`
- `show`
- `index`
- `cancel`

bills:
- `show`
- `index`
- `accept_payment`
- `reject_payment`

Também adicionado verificação no `show` de Bill para não permitir acesso à uma fatura não pertencente ao condomínio informado