### PR TITLE
Emissão de DN por Proprietário e Inquilino

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -27,6 +27,8 @@ class HomeController < ApplicationController
   def find_tenant
     tenant_document_number = params[:get_tenant_bill]
     @tenant = Tenant.find(document_number: tenant_document_number)
+    @unit = Unit.new(@tenant.residence.symbolize_keys) if @tenant.residence.present?
+
     render :index, locals: { tenant: @tenant, bills: find_bills }
   end
 

--- a/app/controllers/nd_certificates_controller.rb
+++ b/app/controllers/nd_certificates_controller.rb
@@ -34,7 +34,7 @@ class NdCertificatesController < ApplicationController
 
   def all_bills_paid?
     @unit_bills = Bill.where(condo_id: @unit.condo_id, unit_id: @unit.id)
-    @unit_bills.all? { |bill| bill.status == 'paid' }
+    @unit_bills.none? { |bill| bill.status != 'paid' }
   end
 
   def create_and_save_certificate
@@ -48,11 +48,11 @@ class NdCertificatesController < ApplicationController
   end
 
   def redirect_to_error
-    redirect_to condo_nd_certificates_path(@unit.condo_id), alert: I18n.t('fail_to_issue')
+    redirect_to root_path, alert: I18n.t('fail_to_issue')
   end
 
   def redirect_to_pending_debts
-    redirect_to condo_nd_certificates_path(@unit.condo_id), notice: I18n.t('pending_debt')
+    redirect_to root_path, notice: I18n.t('pending_debt')
   end
 
   def admin_authorized?

--- a/app/views/home/_tenant_dashboard.html.erb
+++ b/app/views/home/_tenant_dashboard.html.erb
@@ -51,6 +51,9 @@
           <p><%= I18n.t('views.index.no_bills') %></p>
         <% end %>
       </div>
+      <span class="d-block fs-4 text-center">
+        <%= button_to I18n.t('nd_generate'), condo_nd_certificates_path(condo_id: @unit.condo_id, unit_id: @unit.id), method: :post, class: "btn btn-primary" %>
+      </span>
     </div>
   <% end %>
 </div>

--- a/app/views/nd_certificates/certificate.html.erb
+++ b/app/views/nd_certificates/certificate.html.erb
@@ -5,12 +5,13 @@
     <p class="lead"><strong>Unidade:</strong> <%= @unit.number %></p>
 
     <p class="text-justify mt-4">
-      Através deste certificado é declarado que, o PagueAluguel após minuciosa verificação nos registros financeiros e administrativos em seu banco de dados,
-      constatou-se que não há débitos pendentes relacionados a taxas de condomínio, fundo de reserva,
-      multas ou quaisquer outras obrigações financeiras de responsabilidade do proprietário da referida unidade.
-    </p>
+      Certificamos, para os devidos fins, que, 
+      após rigorosa verificação nos registros financeiros e administrativos constantes em nosso banco de dados, 
+      a empresa PagueAluguel constatou a inexistência de débitos pendentes relacionados a taxas de condomínio, 
+      fundo de reserva, multas ou quaisquer outras obrigações financeiras de responsabilidade do proprietário da referida unidade.    </p>
     <p class="text-justify">
-      Esta certidão é válida por 30 (trinta) dias a contar da data de sua emissão e pode ser utilizada para comprovar a regularidade financeira da unidade perante quaisquer instituições ou interessados.
+      Esta certidão é válida por 30 (trinta) dias a contar da data de sua emissão e pode ser utilizada para comprovar a regularidade 
+      financeira da unidade perante quaisquer instituições ou interessados.
     </p>
 
     <p class="lead mt-5"><strong>Data de emissão:</strong> <%= I18n.l(@nd_certificate.issue_date) %></p>

--- a/app/views/nd_certificates/show.html.erb
+++ b/app/views/nd_certificates/show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "modal" do %>
   <div class="dean-modal modal-md" id="unit-modal">
-    <%= link_to "×", condo_nd_certificates_path(@condo.id), class: "btn btn-close btn-sm", id: 'close', aria_label: "Close" %>
+    <%= link_to "", condo_nd_certificates_path(@condo.id), class: "btn btn-close btn-sm", id: 'close', aria_label: "Close" %>
 
     <div class="text-center mt-4 mb-4">
       <span class="fs-7 d-block mb-1"><%= @condo.name%></span>

--- a/app/views/units/show.html.erb
+++ b/app/views/units/show.html.erb
@@ -58,6 +58,10 @@
         </div>
       <% end %>
     <% end %>
+    <div class="text-center">
+      <%= button_to I18n.t('nd_generate'), condo_nd_certificates_path(condo_id: @unit.condo_id, unit_id: @unit.id), method: :post, class: "btn btn-primary" %>
+    </div>
+
 
     <% if @unit.unit_rent_fee.present? && !@unit.unit_has_tenant? %>
       <% rent = @unit.unit_rent_fee %>

--- a/spec/requests/negative_debit_certificate/admin_tries_to_create_nd_certificate_spec.rb
+++ b/spec/requests/negative_debit_certificate/admin_tries_to_create_nd_certificate_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe 'NdCertificates', type: :request do
+  describe 'GET /index' do
+    it 'permite admins autorizados acessar a listagem de unidades' do
+      admin = create(:admin)
+      condos = []
+      condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+      condos << condo
+      unit_types = []
+      unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                 unit_ids: [])
+      units = []
+      units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+      units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+      allow(Condo).to receive(:all).and_return(condos)
+      allow(Condo).to receive(:find).and_return(condo)
+      allow(CommonArea).to receive(:all).and_return([])
+      allow(UnitType).to receive(:all).and_return(unit_types)
+      allow(Unit).to receive(:all).and_return(units)
+      allow(Unit).to receive(:find).and_return(units.first)
+      create(:bill, unit_id: 1, condo_id: 1, status: :paid)
+
+      login_as admin, scope: :admin
+      get condo_nd_certificates_path(condo_id: condo.id)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /create' do
+    context 'sem débitos pendentes' do
+      it 'e emite com sucesso certificado' do
+        admin = create(:admin)
+        condos = []
+        condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+        condos << condo
+        unit_types = []
+        unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                   unit_ids: [])
+        units = []
+        units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        allow(Condo).to receive(:all).and_return(condos)
+        allow(Condo).to receive(:find).and_return(condo)
+        allow(CommonArea).to receive(:all).and_return([])
+        allow(UnitType).to receive(:all).and_return(unit_types)
+        allow(Unit).to receive(:all).and_return(units)
+        allow(Unit).to receive(:find).and_return(units.first)
+        create(:bill, unit_id: 1, condo_id: 1, status: :paid)
+
+        login_as admin, scope: :admin
+        post condo_nd_certificates_path(condo_id: units.first.condo_id, unit_id: units.first.id)
+
+        expect(response).to redirect_to(certificate_condo_nd_certificate_path(condo_id: units.first.condo_id, id: 1))
+        expect(flash[:notice]).to eq(I18n.t('success_issued'))
+      end
+    end
+
+    context 'quando unidade possui debitos pendentes' do
+      it 'nao consegue emitir certificado algum' do
+        admin = create(:admin)
+        condos = []
+        condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+        condos << condo
+        unit_types = []
+        unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                   unit_ids: [])
+        units = []
+        units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        allow(Condo).to receive(:all).and_return(condos)
+        allow(Condo).to receive(:find).and_return(condo)
+        allow(CommonArea).to receive(:all).and_return([])
+        allow(UnitType).to receive(:all).and_return(unit_types)
+        allow(Unit).to receive(:all).and_return(units)
+        allow(Unit).to receive(:find).and_return(units.first)
+        create(:bill, unit_id: 1, condo_id: 1, status: :pending)
+
+        login_as admin, scope: :admin
+        post condo_nd_certificates_path(condo_id: units.first.condo_id, unit_id: units.first.id)
+
+        expect(response).to have_http_status(302)
+        expect(flash[:notice]).to eq(I18n.t('pending_debt'))
+      end
+    end
+  end
+end

--- a/spec/requests/negative_debit_certificate/admin_tries_to_create_nd_certificate_spec.rb
+++ b/spec/requests/negative_debit_certificate/admin_tries_to_create_nd_certificate_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe 'NdCertificates', type: :request do
                                  unit_ids: [])
       units = []
       units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
-                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                        description: 'Com varanda')
       units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
-                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                        condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                        description: 'Com varanda')
       allow(Condo).to receive(:all).and_return(condos)
       allow(Condo).to receive(:find).and_return(condo)
       allow(CommonArea).to receive(:all).and_return([])
@@ -42,9 +44,11 @@ RSpec.describe 'NdCertificates', type: :request do
                                    unit_ids: [])
         units = []
         units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                          description: 'Com varanda')
         units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                          description: 'Com varanda')
         allow(Condo).to receive(:all).and_return(condos)
         allow(Condo).to receive(:find).and_return(condo)
         allow(CommonArea).to receive(:all).and_return([])
@@ -72,9 +76,11 @@ RSpec.describe 'NdCertificates', type: :request do
                                    unit_ids: [])
         units = []
         units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                          description: 'Com varanda')
         units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1,
+                          owner_id: 1, description: 'Com varanda')
         allow(Condo).to receive(:all).and_return(condos)
         allow(Condo).to receive(:find).and_return(condo)
         allow(CommonArea).to receive(:all).and_return([])

--- a/spec/requests/negative_debit_certificate/property_owner_or_tenant_tries_to_create_nd_certificate_spec.rb
+++ b/spec/requests/negative_debit_certificate/property_owner_or_tenant_tries_to_create_nd_certificate_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'NdCertificates', type: :request do
+  describe 'POST /create' do
+    context 'sem débitos pendentes' do
+      it 'e emite com sucesso certificado' do
+        condos = []
+        condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+        condos << condo
+        unit_types = []
+        unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                   unit_ids: [])
+        units = []
+        units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        allow(Condo).to receive(:all).and_return(condos)
+        allow(Condo).to receive(:find).and_return(condo)
+        allow(CommonArea).to receive(:all).and_return([])
+        allow(UnitType).to receive(:all).and_return(unit_types)
+        allow(Unit).to receive(:all).and_return(units)
+        allow(Unit).to receive(:find_all_by_owner).and_return(units)
+        allow(Unit).to receive(:find).and_return(units.first)
+        create(:bill, unit_id: 1, condo_id: 1, status: :paid)
+
+        post condo_nd_certificates_path(condo_id: units.first.condo_id, unit_id: units.first.id)
+
+        expect(response).to redirect_to(certificate_condo_nd_certificate_path(condo_id: units.first.condo_id, id: 1))
+        expect(flash[:notice]).to eq(I18n.t('success_issued'))
+        expect(NdCertificate.count).to eq 1
+      end
+    end
+
+    context 'quando unidade possui debitos pendentes' do
+      it 'nao consegue emitir certificado algum' do
+        condos = []
+        condo = Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'São Paulo')
+        condos << condo
+        unit_types = []
+        unit_types << UnitType.new(id: 1, description: 'Apartamento 1 quarto', metreage: 40, fraction: 0.5,
+                                   unit_ids: [])
+        units = []
+        units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+        allow(Condo).to receive(:all).and_return(condos)
+        allow(Condo).to receive(:find).and_return(condo)
+        allow(CommonArea).to receive(:all).and_return([])
+        allow(UnitType).to receive(:all).and_return(unit_types)
+        allow(Unit).to receive(:all).and_return(units)
+        allow(Unit).to receive(:find).and_return(units.first)
+        create(:bill, unit_id: 1, condo_id: 1, status: :pending)
+
+        post condo_nd_certificates_path(condo_id: units.first.condo_id, unit_id: units.first.id)
+
+        expect(response).to have_http_status(302)
+        expect(flash[:notice]).to eq(I18n.t('pending_debt'))
+        expect(NdCertificate.count).to eq 0
+      end
+    end
+  end
+end

--- a/spec/requests/negative_debit_certificate/property_owner_or_tenant_tries_to_create_nd_certificate_spec.rb
+++ b/spec/requests/negative_debit_certificate/property_owner_or_tenant_tries_to_create_nd_certificate_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe 'NdCertificates', type: :request do
                                    unit_ids: [])
         units = []
         units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                          description: 'Com varanda')
         units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                          description: 'Com varanda')
         allow(Condo).to receive(:all).and_return(condos)
         allow(Condo).to receive(:find).and_return(condo)
         allow(CommonArea).to receive(:all).and_return([])
@@ -42,9 +44,11 @@ RSpec.describe 'NdCertificates', type: :request do
                                    unit_ids: [])
         units = []
         units << Unit.new(id: 1, area: 40, floor: 1, number: '11', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                          description: 'Com varanda')
         units << Unit.new(id: 2, area: 40, floor: 1, number: '12', unit_type_id: 1, condo_id: 1,
-                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1, description: 'Com varanda')
+                          condo_name: 'Condomínio Vila das Flores', tenant_id: 1, owner_id: 1,
+                          description: 'Com varanda')
         allow(Condo).to receive(:all).and_return(condos)
         allow(Condo).to receive(:find).and_return(condo)
         allow(CommonArea).to receive(:all).and_return([])

--- a/spec/system/negative_debt_certificate/admin_tries_to_create_a_nd_certificate_spec.rb
+++ b/spec/system/negative_debt_certificate/admin_tries_to_create_a_nd_certificate_spec.rb
@@ -93,6 +93,7 @@ describe 'Admin tenta emitir certificado de debito negativo' do
     allow(Unit).to receive(:all).and_return(units)
     allow(Unit).to receive(:find).and_return(units.first)
     create(:bill, unit_id: 1, condo_id: 1, status: :pending)
+    create(:bill, unit_id: 1, condo_id: 1, status: :paid)
 
     login_as admin, scope: :admin
     visit condo_path(condo.id)

--- a/spec/system/negative_debt_certificate/property_owner_tries_to_create_a_nd_certificate_spec.rb
+++ b/spec/system/negative_debt_certificate/property_owner_tries_to_create_a_nd_certificate_spec.rb
@@ -2,33 +2,35 @@ require 'rails_helper'
 
 RSpec.describe 'Proprietário tenta emitir certificado de debito negativo' do
   it 'com sucesso' do
-    cpf = CPF.generate
-    allow(Faraday).to receive(:get).and_return(instance_double('Faraday::Response', success?: true))
-    property_owner = create(:property_owner, email: 'propertyownertest@mail.com', password: '123456',
-                                             document_number: cpf)
+    freeze_time do
+      cpf = CPF.generate
+      allow(Faraday).to receive(:get).and_return(instance_double('Faraday::Response', success?: true))
+      property_owner = create(:property_owner, email: 'propertyownertest@mail.com', password: '123456',
+                                               document_number: cpf)
 
-    condos = []
-    condos << Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'City Test')
-    allow(Condo).to receive(:all).and_return(condos)
-    allow(Condo).to receive(:find).and_return(condos.first)
+      condos = []
+      condos << Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'City Test')
+      allow(Condo).to receive(:all).and_return(condos)
+      allow(Condo).to receive(:find).and_return(condos.first)
 
-    units = []
-    units << Unit.new(id: 2, area: 120, floor: 3, number: 22, unit_type_id: 2, owner_name: 'Jules',
-                      tenant_id: 2, owner_id: 1, condo_id: 1, description: 'Apartamento 2 quartos',
-                      condo_name: 'Condo Test')
-    allow(Unit).to receive(:find_all_by_owner).and_return(units)
-    allow(Unit).to receive(:find).and_return(units[0])
-    create(:bill, unit_id: 1, condo_id: 1, status: :paid)
+      units = []
+      units << Unit.new(id: 2, area: 120, floor: 3, number: 22, unit_type_id: 2, owner_name: 'Jules',
+                        tenant_id: 2, owner_id: 1, condo_id: 1, description: 'Apartamento 2 quartos',
+                        condo_name: 'Condo Test')
+      allow(Unit).to receive(:find_all_by_owner).and_return(units)
+      allow(Unit).to receive(:find).and_return(units[0])
+      create(:bill, unit_id: 1, condo_id: 1, status: :paid)
 
-    login_as property_owner, scope: :property_owner
-    visit unit_path(2)
-    click_on 'Emitir Certificado de Débito Negativo'
+      login_as property_owner, scope: :property_owner
+      visit unit_path(2)
+      click_on 'Emitir Certificado de Débito Negativo'
 
-    expect(page).to have_content 'Certidão de quitação emitida com sucesso'
-    expect(page).to have_content I18n.l(Time.zone.now)
-    expect(current_path).to eq certificate_condo_nd_certificate_path(condo_id: condos.first.id, id: 1)
-    expect(page).to have_content 'Condomínio: Condomínio Vila das Flores'
-    expect(page).to have_content 'Unidade: 22'
+      expect(page).to have_content 'Certidão de quitação emitida com sucesso'
+      expect(page).to have_content I18n.l(Time.zone.now)
+      expect(current_path).to eq certificate_condo_nd_certificate_path(condo_id: condos.first.id, id: 1)
+      expect(page).to have_content 'Condomínio: Condomínio Vila das Flores'
+      expect(page).to have_content 'Unidade: 22'
+    end
   end
 
   it 'e falha pois possui débitos pendentes' do

--- a/spec/system/negative_debt_certificate/property_owner_tries_to_create_a_nd_certificate_spec.rb
+++ b/spec/system/negative_debt_certificate/property_owner_tries_to_create_a_nd_certificate_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'Proprietário tenta emitir certificado de debito negativo' do
+  it 'com sucesso' do
+    cpf = CPF.generate
+    allow(Faraday).to receive(:get).and_return(instance_double('Faraday::Response', success?: true))
+    property_owner = create(:property_owner, email: 'propertyownertest@mail.com', password: '123456',
+                                             document_number: cpf)
+
+    condos = []
+    condos << Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'City Test')
+    allow(Condo).to receive(:all).and_return(condos)
+    allow(Condo).to receive(:find).and_return(condos.first)
+
+    units = []
+    units << Unit.new(id: 2, area: 120, floor: 3, number: 22, unit_type_id: 2, owner_name: 'Jules',
+                      tenant_id: 2, owner_id: 1, condo_id: 1, description: 'Apartamento 2 quartos',
+                      condo_name: 'Condo Test')
+    allow(Unit).to receive(:find_all_by_owner).and_return(units)
+    allow(Unit).to receive(:find).and_return(units[0])
+    create(:bill, unit_id: 1, condo_id: 1, status: :paid)
+
+    login_as property_owner, scope: :property_owner
+    visit unit_path(2)
+    click_on 'Emitir Certificado de Débito Negativo'
+
+    expect(page).to have_content 'Certidão de quitação emitida com sucesso'
+    expect(page).to have_content I18n.l(Time.zone.now)
+    expect(current_path).to eq certificate_condo_nd_certificate_path(condo_id: condos.first.id, id: 1)
+    expect(page).to have_content 'Condomínio: Condomínio Vila das Flores'
+    expect(page).to have_content 'Unidade: 22'
+  end
+
+  it 'e falha pois possui débitos pendentes' do
+    cpf = CPF.generate
+    allow(Faraday).to receive(:get).and_return(instance_double('Faraday::Response', success?: true))
+    property_owner = create(:property_owner, email: 'propertyownertest@mail.com', password: '123456',
+                                             document_number: cpf)
+
+    condos = []
+    condos << Condo.new(id: 1, name: 'Condomínio Vila das Flores', city: 'City Test')
+    allow(Condo).to receive(:all).and_return(condos)
+    allow(Condo).to receive(:find).and_return(condos.first)
+
+    units = []
+    units << Unit.new(id: 2, area: 120, floor: 3, number: 22, unit_type_id: 2, owner_name: 'Jules',
+                      tenant_id: 1, owner_id: 1, condo_id: 1, description: 'Apartamento 2 quartos',
+                      condo_name: 'Condo Test')
+    allow(Unit).to receive(:find_all_by_owner).and_return(units)
+    allow(Unit).to receive(:find).and_return(units[0])
+    allow(Unit).to receive(:all).and_return(units[0])
+    create(:bill, unit_id: 2, condo_id: 1, status: :pending)
+    create(:bill, unit_id: 2, condo_id: 1, status: :paid)
+    create(:bill, unit_id: 2, condo_id: 1, status: :awaiting)
+
+    login_as property_owner, scope: :property_owner
+    visit unit_path(2)
+    click_on 'Emitir Certificado de Débito Negativo'
+
+    expect(page).to have_content 'Esta unidade possui débitos pendentes.'
+  end
+end

--- a/spec/system/property_owners/rent_fees/property_owner_manages_rent_spec.rb
+++ b/spec/system/property_owners/rent_fees/property_owner_manages_rent_spec.rb
@@ -155,8 +155,8 @@ describe 'Proprietário configura aluguel' do
     allow(Condo).to receive(:all).and_return(condos)
 
     units = []
-    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
-                      tenant_id: 2, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test', condo_id: 1)
+    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules', condo_id: 1,
+                      tenant_id: 2, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test')
     allow(Unit).to receive(:find_all_by_owner).and_return(units)
     allow(Unit).to receive(:find).and_return(units[0])
     RentFee.create!(owner_id: 1, tenant_id: 2, unit_id: 2, value_cents: 120_000, issue_date: 2.days.from_now.to_date,
@@ -214,8 +214,8 @@ describe 'Proprietário configura aluguel' do
     condos << Condo.new(id: 1, name: 'Condo Test', city: 'City Test')
     allow(Condo).to receive(:all).and_return(condos)
     units = []
-    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
-                      tenant_id: nil, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test', condo_id: 1)
+    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules', condo_id: 1,
+                      tenant_id: nil, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test')
     allow(Unit).to receive(:find_all_by_owner).and_return(units)
     allow(Unit).to receive(:find).and_return(units[0])
     RentFee.create!(owner_id: 1, tenant_id: 2, unit_id: 2, value_cents: 120_000, issue_date: 2.days.from_now.to_date,

--- a/spec/system/property_owners/rent_fees/property_owner_manages_rent_spec.rb
+++ b/spec/system/property_owners/rent_fees/property_owner_manages_rent_spec.rb
@@ -156,7 +156,7 @@ describe 'Proprietário configura aluguel' do
 
     units = []
     units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
-                      tenant_id: 2, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test')
+                      tenant_id: 2, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test', condo_id: 1)
     allow(Unit).to receive(:find_all_by_owner).and_return(units)
     allow(Unit).to receive(:find).and_return(units[0])
     RentFee.create!(owner_id: 1, tenant_id: 2, unit_id: 2, value_cents: 120_000, issue_date: 2.days.from_now.to_date,
@@ -188,7 +188,7 @@ describe 'Proprietário configura aluguel' do
     units = []
     units << Unit.new(id: 3, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
                       tenant_id: 2, owner_id: property_owner.id, description: 'Apartamento 2 quartos',
-                      condo_name: 'Condo Test')
+                      condo_name: 'Condo Test', condo_id: 1)
 
     unit = Unit.new(id: 20, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
                     tenant_id: 2, owner_id: 100, description: 'Apartamento 2 quartos',
@@ -215,7 +215,7 @@ describe 'Proprietário configura aluguel' do
     allow(Condo).to receive(:all).and_return(condos)
     units = []
     units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
-                      tenant_id: nil, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test')
+                      tenant_id: nil, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test', condo_id: 1)
     allow(Unit).to receive(:find_all_by_owner).and_return(units)
     allow(Unit).to receive(:find).and_return(units[0])
     RentFee.create!(owner_id: 1, tenant_id: 2, unit_id: 2, value_cents: 120_000, issue_date: 2.days.from_now.to_date,

--- a/spec/system/property_owners/units/property_owener_view_unit_details_spec.rb
+++ b/spec/system/property_owners/units/property_owener_view_unit_details_spec.rb
@@ -12,7 +12,7 @@ describe 'Proprietário vee detalhes da sua unidade' do
     allow(Condo).to receive(:all).and_return(condos)
 
     units = []
-    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
+    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules', condo_id: 1,
                       tenant_id: 2, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test')
     allow(Unit).to receive(:find_all_by_owner).and_return(units)
     allow(Unit).to receive(:find).and_return(units[0])
@@ -41,7 +41,7 @@ describe 'Proprietário vee detalhes da sua unidade' do
     allow(Condo).to receive(:all).and_return(condos)
 
     units = []
-    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
+    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules', condo_id: 1,
                       tenant_id: nil, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test')
     allow(Unit).to receive(:find_all_by_owner).and_return(units)
     allow(Unit).to receive(:find).and_return(units[0])
@@ -70,7 +70,7 @@ describe 'Proprietário vee detalhes da sua unidade' do
     allow(Condo).to receive(:all).and_return(condos)
 
     units = []
-    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules',
+    units << Unit.new(id: 2, area: 120, floor: 3, number: 4, unit_type_id: 2, owner_name: 'Jules', condo_id: 1,
                       tenant_id: 1, owner_id: 1, description: 'Apartamento 2 quartos', condo_name: 'Condo Test')
     allow(Unit).to receive(:find_all_by_owner).and_return(units)
     allow(Unit).to receive(:find).and_return(units[0])


### PR DESCRIPTION
Este PR implementa a funcionalidade de emissão de certificado de débito negativo para proprietários e inquilinos.

O que foi feito :
- Proprietário ao ver suas unidades pode emitir o certificado de DN
- Inquilino ao acessar a aplicação e informar seu CPF para ver as faturas, pode emitir um certificado de DN

![image](https://github.com/user-attachments/assets/10dd7395-19fd-41e8-8cea-3604c7c2b524)

![image](https://github.com/user-attachments/assets/5d25f436-1615-4da4-8eba-d5f0aeef2ba9)

![image](https://github.com/user-attachments/assets/efeef266-c337-4fad-9297-3a218ab43e9e)
