### PR TITLE
Corrige o bug presente nas seeds

### DIFF
--- a/app/models/single_charge.rb
+++ b/app/models/single_charge.rb
@@ -26,6 +26,10 @@ class SingleCharge < ApplicationRecord
     other: 5
   }
 
+  def self.skip_api_validation
+    @skip_api_validation = true
+  end
+
   private
 
   def common_area_restriction
@@ -60,9 +64,5 @@ class SingleCharge < ApplicationRecord
     return if units.any? { |unit| unit.id == unit_id }
 
     errors.add(:unit_id, 'deve pertencer ao condomínio')
-  end
-
-  def self.skip_api_validation
-    @skip_api_validation = true
   end
 end

--- a/app/models/single_charge.rb
+++ b/app/models/single_charge.rb
@@ -1,9 +1,11 @@
 class SingleCharge < ApplicationRecord
+  attr_accessor :skip_api_validation
+
   validates :unit_id, :issue_date, presence: true
   validate :common_area_is_mandatory
   validate :date_is_future
   validate :description_is_mandatory
-  validate :unit_belongs_to_condo
+  validate :unit_belongs_to_condo, unless: :skip_api_validation
 
   before_create :common_area_restriction
 
@@ -58,5 +60,9 @@ class SingleCharge < ApplicationRecord
     return if units.any? { |unit| unit.id == unit_id }
 
     errors.add(:unit_id, 'deve pertencer ao condomínio')
+  end
+
+  def self.skip_api_validation
+    @skip_api_validation = true
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -164,27 +164,27 @@ p "Created #{SharedFee.count} shared fees"
 
 SingleCharge.create!(unit_id: 97, value_cents: 150_00,
                     issue_date: 15.days.from_now, description: 'Taxa de pintura',
-                    charge_type: :fine, condo_id: 2, status: 0)
+                    charge_type: :fine, condo_id: 2, status: 0, skip_api_validation: true)
 
 SingleCharge.create!(unit_id: 97, value_cents: 250_00,
                     issue_date: 10.days.from_now, description: 'Reparos na área comum',
-                    charge_type: :fine, condo_id: 2, status: 5)
+                    charge_type: :fine, condo_id: 2, status: 5, skip_api_validation: true)
 
 SingleCharge.create!(unit_id: 97, value_cents: 500_00,
                     issue_date: 5.days.from_now, description: 'Reparos de elevador',
-                    charge_type: :fine, condo_id: 2, status: 0)
+                    charge_type: :fine, condo_id: 2, status: 0, skip_api_validation: true)
 
 SingleCharge.create!(unit_id: 97, value_cents: 300_00,
                     issue_date: 7.days.from_now, description: 'Taxa de limpeza',
-                    charge_type: :fine, condo_id: 2, status: 0)
+                    charge_type: :fine, condo_id: 2, status: 0, skip_api_validation: true)
 
 SingleCharge.create!(unit_id: 97, value_cents: 100_00,
                     issue_date: 25.days.from_now, description: 'Reforma no jardim',
-                    charge_type: :fine, condo_id: 2, status: 0)
+                    charge_type: :fine, condo_id: 2, status: 0, skip_api_validation: true)
 
 SingleCharge.create!(unit_id: 97, value_cents: 9750_00,
                     issue_date: 30.days.from_now, description: 'Reparos elétricos',
-                    charge_type: :fine, condo_id: 2, status: 0)
+                    charge_type: :fine, condo_id: 2, status: 0, skip_api_validation: true)
 
 p "Created #{SingleCharge.count} single charge"
 
@@ -280,7 +280,7 @@ p "Created 3 bills for 314.787.200-93"
 p "Created 5 bills for 458.456.480-92"
 
 Receipt.create!(bill_id: 2, file: Rails.root.join('app', 'assets', 'images', 'cupom-fiscal.jpg').open)
-Receipt.create!(bill_id: 3, file: Rails.root.join('app', 'assets', 'images', 'Comprovante-pg.jpg').open)
+Receipt.create!(bill_id: 3, file: Rails.root.join('app', 'assets', 'images', 'comprovante-pg.jpg').open)
 Receipt.create!(bill_id: 5, file: Rails.root.join('app', 'assets', 'images', 'cupom-fiscal.jpg').open)
 Receipt.create!(bill_id: 6, file: Rails.root.join('app', 'assets', 'images', 'cupom-fiscal.jpg').open)
 Receipt.create!(bill_id: 7, file: Rails.root.join('app', 'assets', 'images', 'cupom-fiscal.jpg').open)


### PR DESCRIPTION
Adicione uma maneira de ignorar as validações belong_to_condo nas seeds, para evitar requisições durante o rails db:seed e prevenir erros caso a API condominions esteja offline.