### PR TITLE
Rafatoração de chamadas da API para proprietário

### DIFF
--- a/app/models/property_owner.rb
+++ b/app/models/property_owner.rb
@@ -11,15 +11,16 @@ class PropertyOwner < ApplicationRecord
   private
 
   def document_number_must_be_valid
-    return if cpf_valid?(document_number)
+    return if document_number_valid?(document_number)
 
     errors.add(:document_number, :invalid, message: I18n.t('devise.failure.invalid_document_number'))
   end
 
-  def cpf_valid?(cpf)
-    return false if cpf.blank?
+  def document_number_valid?(document_number)
+    return false if document_number.blank?
 
-    url = "#{Rails.configuration.api['base_url']}/property?cpf=#{cpf}"
+    registration_number = CPF.new(document_number).formatted
+    url = "#{Rails.configuration.api['base_url']}/check_owner?registration_number=#{registration_number}"
     response = Faraday.get(url)
     response.success?
   end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -35,8 +35,11 @@ class Unit
     build_new_unit(data)
   end
 
-  def self.find_all_by_owner(cpf)
-    response = Faraday.get("#{Rails.configuration.api['base_url']}/get_owner_properties?registration_number=#{cpf}")
+  def self.find_all_by_owner(document_number)
+    registration_number = CPF.new(document_number).formatted
+    response = Faraday.get(
+      "#{Rails.configuration.api['base_url']}/get_owner_properties?registration_number=#{registration_number}"
+    )
     return [] unless response.success?
 
     data = JSON.parse(response.body)

--- a/spec/models/property_owner_spec.rb
+++ b/spec/models/property_owner_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PropertyOwner, type: :model do
   context 'shoulda_matchers' do
     before do
-      allow_any_instance_of(PropertyOwner).to receive(:cpf_valid?).and_return(true)
+      allow_any_instance_of(PropertyOwner).to receive(:document_number_valid?).and_return(true)
     end
     it { should validate_presence_of(:email) }
     it { should validate_presence_of(:password) }
@@ -12,11 +12,13 @@ RSpec.describe PropertyOwner, type: :model do
   end
 
   it 'com CPF válido' do
-    cpf = CPF.generate
+    cpf = CPF.new(CPF.generate).formatted
     fake_response = double('faraday_response', success?: true, body: 'Proprietário')
 
     allow(Faraday).to(
-      receive(:get).with("#{Rails.configuration.api['base_url']}/property?cpf=#{cpf}").and_return(fake_response)
+      receive(:get).with(
+        "#{Rails.configuration.api['base_url']}/check_owner?registration_number=#{cpf}"
+      ).and_return(fake_response)
     )
 
     owner = PropertyOwner.new(email: 'solidsnake@mgs.com', password: 'password', document_number: cpf)
@@ -25,11 +27,13 @@ RSpec.describe PropertyOwner, type: :model do
   end
 
   it 'com CPF inválido' do
-    cpf = CPF.generate
+    cpf = CPF.new(CPF.generate).formatted
     fake_response = double('faraday_response', success?: false, body: 'Proprietário')
 
     allow(Faraday).to(
-      receive(:get).with("#{Rails.configuration.api['base_url']}/property?cpf=#{cpf}").and_return(fake_response)
+      receive(:get).with(
+        "#{Rails.configuration.api['base_url']}/check_owner?registration_number=#{cpf}"
+      ).and_return(fake_response)
     )
 
     owner = PropertyOwner.new(email: 'solidsnake@mgs.com', password: 'password', document_number: cpf)

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -44,7 +44,7 @@ describe Unit do
 
   context '.find_all_by_owner' do
     it 'retorna todas as unidades de um proprietario' do
-      cpf = CPF.generate
+      cpf = CPF.new(CPF.generate).formatted
       data = Rails.root.join('spec/support/json/owner_units.json').read
       response = double('response', success?: true, body: data)
       allow(Faraday).to(


### PR DESCRIPTION
o que foi feito: 
- Refatoração dos métodos de chamada "find_all_by_owner" e "document_number_valid?" enviando como parâmetro o CPF formatado "xxx.xxx.xxx-xx"
- Refatoração de mocks nos testes para refletir a mudança acima