### PR TITLE
Corrige calculo do aluguel no BillCalculator

### DIFF
--- a/app/models/bill_calculator.rb
+++ b/app/models/bill_calculator.rb
@@ -67,17 +67,13 @@ class BillCalculator
   end
 
   def self.check_rent_fee(unit_id)
-    rent_fee = get_last_month_rent_fee(unit_id)
+    rent_fee = get_rent_fee(unit_id)
     rent_fee&.value_cents || 0
   end
 
-  def self.get_last_month_rent_fee(unit_id)
-    now = Time.zone.now
-    last_month = now.last_month
-    start_of_last_month = last_month.beginning_of_month
-    end_of_last_month = last_month.end_of_month
-    RentFee.find_by(unit_id:, issue_date: start_of_last_month..end_of_last_month, status: :active)
+  def self.get_rent_fee(unit_id)
+    RentFee.find_by(unit_id:, status: :active)
   end
 
-  private_class_method :get_last_month_fractions, :get_last_month_single_charges, :get_last_month_rent_fee
+  private_class_method :get_last_month_fractions, :get_last_month_single_charges, :get_rent_fee
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -230,21 +230,21 @@ SingleCharge.create!(unit_id: 97, value_cents: 9750_00,
   bill3 = Bill.create!(
     unit_id: 97,
     condo_id: 2,
-    base_fee_value_cents: 560_00,
-    shared_fee_value_cents: 570_00,
-    single_charge_value_cents: 200_00,
-    total_value_cents: 560_00 + 570_00 + 200_00,
+    base_fee_value_cents: 360_00,
+    shared_fee_value_cents: 170_00,
+    single_charge_value_cents: 290_00,
+    total_value_cents: 360_00 + 170_00 + 290_00,
     rent_fee_cents: 0,
     issue_date: 2.months.ago.beginning_of_month,
     due_date: 2.months.ago.beginning_of_month + 9.days,
     status: :paid,
     denied: false
   )
-  BillDetail.create!(bill_id: bill3.id, description: 'Multa por Estacionamento Indevido', value_cents: 90_00, fee_type: :fine)
   BillDetail.create!(bill_id: bill3.id, description: 'Taxa de Administração', value_cents: 60_00, fee_type: :base_fee)
-  BillDetail.create!(bill_id: bill3.id, description: 'Conta de Internet', value_cents: 70_00, fee_type: :shared_fee)
   BillDetail.create!(bill_id: bill3.id, description: 'Taxa de Reparos Estruturais', value_cents: 300_00, fee_type: :base_fee)
-  BillDetail.create!(bill_id: bill3.id, description: 'Despesas Comuns', value_cents: 500_00, fee_type: :shared_fee)
+  BillDetail.create!(bill_id: bill3.id, description: 'Conta de Internet', value_cents: 70_00, fee_type: :shared_fee)
+  BillDetail.create!(bill_id: bill3.id, description: 'Despesas Comuns', value_cents: 100_00, fee_type: :shared_fee)
+  BillDetail.create!(bill_id: bill3.id, description: 'Multa por Estacionamento Indevido', value_cents: 90_00, fee_type: :fine)
   BillDetail.create!(bill_id: bill3.id, description: 'Acordo sobre Pagamento Atrasado', value_cents: 200_00, fee_type: :other)
 
   bill4 = Bill.create!(
@@ -338,6 +338,6 @@ SingleCharge.create!(unit_id: 97, value_cents: 9750_00,
   sleep(1)
   Receipt.create!(bill_id: bill7.id, file: Rails.root.join('app', 'assets', 'images', 'cupom-fiscal.jpg').open)
   p "Created 1 more Receipt with image"
-  
+
   p "Created #{Receipt.count} receipts"
   p "All done :)"

--- a/lib/tasks/batch.rake
+++ b/lib/tasks/batch.rake
@@ -3,7 +3,7 @@ namespace :batch do
   task generate_bills: :environment do
     condos = Condo.all
     condos.each do |condo|
-      units = Unit.find_all_by_condo(condo.id)
+      units = Unit.all(condo.id)
       units.each do |unit|
         GenerateMonthlyBillJob.perform_now(unit, condo.id)
       end

--- a/spec/system/bills/admin_views_details_of_bill_spec.rb
+++ b/spec/system/bills/admin_views_details_of_bill_spec.rb
@@ -169,7 +169,7 @@ describe 'Admin vê detalhes de uma fatura' do
       shared_fee = create(:shared_fee, description: 'Conta de Água', issue_date: Time.zone.today,
                                        total_value: 3_000, condo_id: condos.first.id)
       create(:shared_fee_fraction, shared_fee:, unit_id: 1, value_cents: 300_00)
-      shared_fee2 = create(:shared_fee, description: 'Conta de Luz', issue_date: 9.days.from_now.to_date,
+      shared_fee2 = create(:shared_fee, description: 'Conta de Luz', issue_date: Time.zone.today,
                                         total_value: 1_000, condo_id: condos.first.id)
       create(:shared_fee_fraction, shared_fee: shared_fee2, unit_id: 1, value_cents: 100_00)
       base_fee = create(:base_fee, condo_id: condos.first.id, charge_day: Time.zone.today)


### PR DESCRIPTION
Esse PR corrige um detalhe sobre a inclusão do aluguel no cálculo da fatura, e conserta o batch.rake.